### PR TITLE
Support an array for pidfile_workaround + skip CentOS 8

### DIFF
--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -31,7 +31,14 @@ module PuppetMetadata
       if pidfile_workaround
         case os
         when 'CentOS'
-          options[:image] = 'centos:7.6.1810' if release == '7'
+          case release
+          when '7'
+            options[:image] = 'centos:7.6.1810'
+          when '8'
+            # There is no CentOS 8 image that works with PIDFile in systemd
+            # unit files
+            return
+          end
         when 'Ubuntu'
           options[:image] = 'ubuntu:xenial-20191212' if release == '16.04'
         end

--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -12,11 +12,13 @@ module PuppetMetadata
     # @param [String] release The OS release
     # @param [Boolean] use_fqdn
     #   Whether or not to use a FQDN, ensuring a domain
-    # @param [Boolean] pidfile_workaround
+    # @param [Boolean, Array[String]] pidfile_workaround
     #   Whether or not to apply the systemd PIDFile workaround. This is only
     #   needed when the daemon uses PIDFile in its service file and using
     #   Docker as a Beaker hypervisor. This is to work around Docker's
     #   limitations.
+    #   When a boolean, it's applied on applicable operating systems. On arrays
+    #   it's applied only when os is included in the provided array.
     #
     # @return [String] The beaker setfile description or nil
     def self.os_release_to_setfile(os, release, use_fqdn: false, pidfile_workaround: false)
@@ -26,9 +28,10 @@ module PuppetMetadata
 
       options = {}
       options[:hostname] = "#{name}.example.com" if use_fqdn
+
       # Docker messes up cgroups and modern systemd can't deal with that when
       # PIDFile is used.
-      if pidfile_workaround
+      if pidfile_workaround && (!pidfile_workaround.is_a?(Array) || pidfile_workaround.include?(os))
         case os
         when 'CentOS'
           case release

--- a/spec/beaker_spec.rb
+++ b/spec/beaker_spec.rb
@@ -19,8 +19,9 @@ describe PuppetMetadata::Beaker do
 
     describe 'pidfile_workaround' do
       [
+        ['CentOS', '6', 'centos6-64'],
         ['CentOS', '7', 'centos7-64{image=centos:7.6.1810}'],
-        ['CentOS', '8', 'centos8-64'],
+        ['CentOS', '8', nil],
         ['Ubuntu', '16.04', 'ubuntu1604-64{image=ubuntu:xenial-20191212}'],
         ['Ubuntu', '18.04', 'ubuntu1804-64'],
       ].each do |os, release, expected|

--- a/spec/beaker_spec.rb
+++ b/spec/beaker_spec.rb
@@ -18,18 +18,26 @@ describe PuppetMetadata::Beaker do
     it { expect(described_class.os_release_to_setfile('SLES', '11')).to be_nil }
 
     describe 'pidfile_workaround' do
-      [
-        ['CentOS', '6', 'centos6-64'],
-        ['CentOS', '7', 'centos7-64{image=centos:7.6.1810}'],
-        ['CentOS', '8', nil],
-        ['Ubuntu', '16.04', 'ubuntu1604-64{image=ubuntu:xenial-20191212}'],
-        ['Ubuntu', '18.04', 'ubuntu1804-64'],
-      ].each do |os, release, expected|
-        it { expect(described_class.os_release_to_setfile(os, release, pidfile_workaround: true)).to eq(expected) }
+      describe 'true' do
+        [
+          ['CentOS', '6', 'centos6-64'],
+          ['CentOS', '7', 'centos7-64{image=centos:7.6.1810}'],
+          ['CentOS', '8', nil],
+          ['Ubuntu', '16.04', 'ubuntu1604-64{image=ubuntu:xenial-20191212}'],
+          ['Ubuntu', '18.04', 'ubuntu1804-64'],
+        ].each do |os, release, expected|
+          it { expect(described_class.os_release_to_setfile(os, release, pidfile_workaround: true)).to eq(expected) }
+        end
+
+        describe 'use_fqdn' do
+          it { expect(described_class.os_release_to_setfile('CentOS', '7', pidfile_workaround: true, use_fqdn: true)).to eq('centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}') }
+        end
       end
 
-      describe 'use_fqdn' do
-        it { expect(described_class.os_release_to_setfile('CentOS', '7', pidfile_workaround: true, use_fqdn: true)).to eq('centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}') }
+      describe 'as an array' do
+        it { expect(described_class.os_release_to_setfile('CentOS', '8', pidfile_workaround: [])).to eq('centos8-64') }
+        it { expect(described_class.os_release_to_setfile('CentOS', '8', pidfile_workaround: ['Debian'])).to eq('centos8-64') }
+        it { expect(described_class.os_release_to_setfile('CentOS', '8', pidfile_workaround: ['CentOS'])).to be_nil }
       end
     end
   end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -182,7 +182,6 @@ describe PuppetMetadata::Metadata do
         it 'works when passing pidfile_workaround' do
           expected = [
             'centos7-64{image=centos:7.6.1810}',
-            'centos8-64',
             'debian9-64',
             'debian10-64',
             'ubuntu1404-64',


### PR DESCRIPTION
The PIDFile workaround is needed when the service file includes it. This is true for puppetserver where all service files are the same. It isn't true for ISC bind where it's distro specific. This allows selecting those.

There is no CentOS 8 image where a service works that uses PIDFile. This skips the OS version altogether.