### PR TITLE
Handle modules without a Puppet version upper bound

### DIFF
--- a/lib/puppet_metadata/metadata.rb
+++ b/lib/puppet_metadata/metadata.rb
@@ -141,7 +141,11 @@ module PuppetMetadata
       requirement = requirements['puppet']
       raise Exception, 'No Puppet requirement found' unless requirement
 
-      (requirement.begin.major..requirement.end.major).select do |major|
+      # Current latest major is 7. It is highly recommended that modules
+      # actually specify exact bounds, but this prevents an infinite loop.
+      end_major = requirement.end == SemanticPuppet::Version::MAX ? 7 : requirement.end.major
+
+      (requirement.begin.major..end_major).select do |major|
         requirement.include?(SemanticPuppet::Version.new(major, 0, 0)) || requirement.include?(SemanticPuppet::Version.new(major, 99, 99))
       end
     end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -125,6 +125,32 @@ describe PuppetMetadata::Metadata do
 
       describe '#puppet_major_versions' do
         it { expect(subject.puppet_major_versions).to eq([5, 6]) }
+
+        context 'with no lower bound' do
+          let(:metadata) do
+            super().merge(requirements: [
+              {
+                name: 'puppet',
+                version_requirement: '< 7.0.0',
+              },
+            ])
+          end
+
+          it { expect(subject.puppet_major_versions).to eq([0, 1, 2, 3, 4, 5, 6]) }
+        end
+
+        context 'with no upper bound' do
+          let(:metadata) do
+            super().merge(requirements: [
+              {
+                name: 'puppet',
+                version_requirement: '>= 5.5.8',
+              },
+            ])
+          end
+
+          it { expect(subject.puppet_major_versions).to eq([5, 6, 7]) }
+        end
       end
 
       describe '#dependencies' do


### PR DESCRIPTION
If there is no upper bound specified, the version is set to infinity. This leads to an infinite loop. While this code makes a hardcoded upper version, it's better than the alternative.