### PR TITLE
Also present test matrix rows as flat rows

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -9,9 +9,13 @@ module PuppetMetadata
 
     # @return [Hash[Symbol, Any]] The outputs for Github Actions
     def outputs(beaker_use_fqdn: false, beaker_pidfile_workaround: false)
+      beaker_setfiles = beaker_setfiles(beaker_use_fqdn, beaker_pidfile_workaround)
       {
-        beaker_setfiles: beaker_setfiles(beaker_use_fqdn, beaker_pidfile_workaround),
+        beaker_setfiles: beaker_setfiles,
+        beaker_setfile_names: beaker_setfiles.map { |setfile| setfile[:name] },
+        beaker_setfile_values: Hash[beaker_setfiles.map { |setfile| [setfile[:name], setfile[:value]] }],
         puppet_major_versions: puppet_major_versions,
+        puppet_major_version_numbers: metadata.puppet_major_versions.sort.reverse,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
       }
     end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -34,7 +34,7 @@ describe PuppetMetadata::GithubActions do
     subject { super().outputs }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix) }
+    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :beaker_setfile_names, :beaker_setfile_values, :puppet_major_versions, :puppet_major_version_numbers, :puppet_unit_test_matrix) }
 
     describe 'beaker_setfiles' do
       subject { super()[:beaker_setfiles] }
@@ -47,6 +47,29 @@ describe PuppetMetadata::GithubActions do
           {name: "Debian 9", value: "debian9-64"},
           {name: "Debian 10", value: "debian10-64"},
         )
+      end
+    end
+
+    describe 'beaker_setfile_names' do
+      subject { super()[:beaker_setfile_names] }
+
+      it { is_expected.to be_an_instance_of(Array) }
+      it 'is expected to contain CentOS 7 and 8 + Debian 9 and 10' do
+        is_expected.to contain_exactly("CentOS 7", "CentOS 8", "Debian 9", "Debian 10")
+      end
+    end
+
+    describe 'beaker_setfile_values' do
+      subject { super()[:beaker_setfile_values] }
+
+      it { is_expected.to be_an_instance_of(Hash) }
+      it 'is expected to contain CentOS 7 and 8 + Debian 9 and 10' do
+        is_expected.to eq({
+          "CentOS 7" => "centos7-64",
+          "CentOS 8" => "centos8-64",
+          "Debian 9" => "debian9-64",
+          "Debian 10" => "debian10-64",
+        })
       end
     end
 
@@ -63,6 +86,15 @@ describe PuppetMetadata::GithubActions do
           {collection: "puppet4", name: "Puppet 4", value: 4},
           {collection: "puppet3", name: "Puppet 3", value: 3},
         )
+      end
+    end
+
+    describe 'puppet_major_version_numbers' do
+      subject { super()[:puppet_major_version_numbers] }
+
+      it { is_expected.to be_an_instance_of(Array) }
+      it 'is expected to contain major versions 3, 4, 5, 6, 7 and 8' do
+        is_expected.to eq([8, 7, 6, 5, 4, 3])
       end
     end
 


### PR DESCRIPTION
It turns out that using hashes as matrix rows makes it impossible to exclude combinations such as Ubuntu 20.04 + Puppet 5 (for which no packages exist).

The chosen solution is to add additional definitions which can be mapped.

In the case of setfiles, it's preferred to have a matrix based on beaker_setfile_names and then use beaker_setfile_values with the name as a key. This gives the actual setfile.

There is no method data to build the collection. This is rather trivial and probably keeps the actual use easier.

All old structures are still present for compatibility.

This doesn't document it in README yet since there can still be some bikeshedding over names.