### PR TITLE
Track known-bad os and puppet combinations

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -13,6 +13,7 @@ module PuppetMetadata
         beaker_setfiles: beaker_setfiles(beaker_use_fqdn, beaker_pidfile_workaround),
         puppet_major_versions: puppet_major_versions,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
+        known_bad_combinations: known_bad_combinations(beaker_setfiles(beaker_use_fqdn, beaker_pidfile_workaround), puppet_major_versions),
       }
     end
 
@@ -62,6 +63,36 @@ module PuppetMetadata
       when 7
         '2.7'
       end
+    end
+
+    def known_bad_combinations(beaker_setfiles, puppet_major_versions)
+      supporder_versions = {
+        'CentOS 5'     => 5..7,
+        'CentOS 6'     => 5..7,
+        'CentOS 7'     => 5..7,
+        'CentOS 8'     => 5..7,
+        'Debian 7'     => [5],
+        'Debian 8'     => 5..7,
+        'Debian 9'     => 5..7,
+        'Debian 10'    => 5..7,
+        'Ubuntu 14.04' => 5..6,
+        'Ubuntu 16.04' => 5..7,
+        'Ubuntu 18.04' => 5..7,
+        'Ubuntu 20.04' => 6..7,
+      }
+
+      known_bad = []
+      beaker_setfiles.each do |setfile|
+        puppet_major_versions.each do |puppet|
+          if !supporder_versions[setfile[:name]] || !supporder_versions[setfile[:name]].include?(puppet[:value])
+            known_bad << {
+              setfile: setfile,
+              puppet: puppet,
+            }
+          end
+        end
+      end
+      known_bad
     end
   end
 end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -34,7 +34,7 @@ describe PuppetMetadata::GithubActions do
     subject { super().outputs }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix) }
+    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix, :known_bad_combinations) }
 
     describe 'beaker_setfiles' do
       subject { super()[:beaker_setfiles] }
@@ -76,6 +76,64 @@ describe PuppetMetadata::GithubActions do
           {puppet: 6, ruby: "2.5"},
           {puppet: 5, ruby: "2.4"},
           {puppet: 4, ruby: "2.1"},
+        )
+      end
+    end
+
+    describe 'known_bad_combinations' do
+      subject { super()[:known_bad_combinations] }
+
+      it { is_expected.to be_an_instance_of(Array) }
+      it 'is expected to include outdated Puppet versions' do
+        is_expected.to contain_exactly(
+          {
+            setfile: {name: "CentOS 7", value: "centos7-64"},
+            puppet: {collection: "puppet8", name: "Puppet 8", value: 8},
+          },
+          {
+            setfile: {name: "CentOS 7", value: "centos7-64"},
+            puppet: {collection: "puppet4", name: "Puppet 4", value: 4},
+          },
+          {
+            setfile: {name: "CentOS 7", value: "centos7-64"},
+            puppet: {collection: "puppet3", name: "Puppet 3", value: 3},
+          },
+          {
+            setfile: {name: "CentOS 8", value: "centos8-64"},
+            puppet: {collection: "puppet8", name: "Puppet 8", value: 8},
+          },
+          {
+            setfile: {name: "CentOS 8", value: "centos8-64"},
+            puppet: {collection: "puppet4", name: "Puppet 4", value: 4},
+          },
+          {
+            setfile: {name: "CentOS 8", value: "centos8-64"},
+            puppet: {collection: "puppet3", name: "Puppet 3", value: 3},
+          },
+          {
+            setfile: {name: "Debian 9", value: "debian9-64"},
+            puppet: {collection: "puppet8", name: "Puppet 8", value: 8},
+          },
+          {
+            setfile: {name: "Debian 9", value: "debian9-64"},
+            puppet: {collection: "puppet4", name: "Puppet 4", value: 4},
+          },
+          {
+            setfile: {name: "Debian 9", value: "debian9-64"},
+            puppet: {collection: "puppet3", name: "Puppet 3", value: 3},
+          },
+          {
+            setfile: {name: "Debian 10", value: "debian10-64"},
+            puppet: {collection: "puppet8", name: "Puppet 8", value: 8},
+          },
+          {
+            setfile: {name: "Debian 10", value: "debian10-64"},
+            puppet: {collection: "puppet4", name: "Puppet 4", value: 4},
+          },
+          {
+            setfile: {name: "Debian 10", value: "debian10-64"},
+            puppet: {collection: "puppet3", name: "Puppet 3", value: 3},
+          },
         )
       end
     end


### PR DESCRIPTION
This is used to avoid running acceptance tests on systems where versions
of Puppet are not supported (yet or anymore).