### PR TITLE
Track known-good os and puppet combinations

### DIFF
--- a/lib/puppet_metadata.rb
+++ b/lib/puppet_metadata.rb
@@ -1,5 +1,6 @@
 # A module that provides abstractions around Puppet's metadata format.
 module PuppetMetadata
+  autoload :AIO, 'puppet_metadata/aio'
   autoload :Beaker, 'puppet_metadata/beaker'
   autoload :GithubActions, 'puppet_metadata/github_actions'
   autoload :Metadata, 'puppet_metadata/metadata'

--- a/lib/puppet_metadata/aio.rb
+++ b/lib/puppet_metadata/aio.rb
@@ -1,7 +1,12 @@
 module PuppetMetadata
   class AIO 
     COMPATIBLE = {
+      'AlmaLinux'   => 'RedHat',
+      'Amazon'      => 'RedHat',
       'CentOS'      => 'RedHat',
+      'OracleLinux' => 'RedHat',
+      'Rocky'       => 'RedHat',
+      'Scientific'  => 'RedHat',
     }
 
     BUILDS = { 
@@ -22,7 +27,11 @@ module PuppetMetadata
         '32' => 6..7,
         '34' => 6..7,
       },
-      # TODO: SLES/Suse
+      'SLES' => {
+        '11' => [7],
+        '12' => [7],
+        '15' => [7],
+      },
       # deb-based
       'Debian' => {
         '7' => [5],

--- a/lib/puppet_metadata/aio.rb
+++ b/lib/puppet_metadata/aio.rb
@@ -1,8 +1,12 @@
 module PuppetMetadata
   class AIO 
+    COMPATIBLE = {
+      'CentOS'      => 'RedHat',
+    }
+
     BUILDS = { 
       # RPM-based
-      'CentOS' => {
+      'RedHat' => {
         '5' => 5..7,
         '6' => 5..7,
         '7' => 5..7,
@@ -34,9 +38,12 @@ module PuppetMetadata
       },
     }
 
+    def self.find_base_os(os)
+      COMPATIBLE.fetch(os, os)
+    end
+
     def self.has_aio_build?(os, release, puppet_version)
-      # TODO: group CentOS with RedHat/AlmaLinux/Rocky?
-      BUILDS.dig(os, release)&.include?(puppet_version)
+      BUILDS.dig(find_base_os(os), release)&.include?(puppet_version)
     end
   end
 end

--- a/lib/puppet_metadata/aio.rb
+++ b/lib/puppet_metadata/aio.rb
@@ -1,0 +1,42 @@
+module PuppetMetadata
+  class AIO 
+    BUILDS = { 
+      # RPM-based
+      'CentOS' => {
+        '5' => 5..7,
+        '6' => 5..7,
+        '7' => 5..7,
+        '8' => 5..7,
+      },
+      'Fedora' => {
+        '26' => [5],
+        '27' => 5..6,
+        '28' => 5..6,
+        '29' => 5..6,
+        '30' => 5..7,
+        '31' => 5..7,
+        '32' => 6..7,
+        '34' => 6..7,
+      },
+      # TODO: SLES/Suse
+      # deb-based
+      'Debian' => {
+        '7' => [5],
+        '8' => 5..7,
+        '9' => 5..7,
+        '10' => 5..7,
+      },
+      'Ubuntu' => {
+        '14.04' => 5..6,
+        '16.04' => 5..7,
+        '18.04' => 5..7,
+        '20.04' => 6..7,
+      },
+    }
+
+    def self.has_aio_build?(os, release, puppet_version)
+      # TODO: group CentOS with RedHat/AlmaLinux/Rocky?
+      BUILDS.dig(os, release)&.include?(puppet_version)
+    end
+  end
+end

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -75,6 +75,8 @@ module PuppetMetadata
             next unless AIO.has_aio_build?(os, release, puppet_version[:value])
 
             setfile = PuppetMetadata::Beaker.os_release_to_setfile(os, release, use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround)
+            next unless setfile
+
             matrix_include << {
               setfile: {
                 name: setfile[1],

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -69,9 +69,9 @@ module PuppetMetadata
     def github_action_test_matrix(use_fqdn: false, pidfile_workaround: false)
       matrix_include = []
 
-      puppet_major_versions.each do |puppet_version|
-        metadata.operatingsystems.each do |os, releases|
-          releases&.each do |release|
+      metadata.operatingsystems.each do |os, releases|
+        releases&.each do |release|
+          puppet_major_versions.each do |puppet_version|
             next unless AIO.has_aio_build?(os, release, puppet_version[:value])
 
             setfile = PuppetMetadata::Beaker.os_release_to_setfile(os, release, use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround)

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -34,7 +34,7 @@ describe PuppetMetadata::GithubActions do
     subject { super().outputs }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix) }
+    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix, :github_action_test_matrix) }
 
     describe 'beaker_setfiles' do
       subject { super()[:beaker_setfiles] }
@@ -76,6 +76,28 @@ describe PuppetMetadata::GithubActions do
           {puppet: 6, ruby: "2.5"},
           {puppet: 5, ruby: "2.4"},
           {puppet: 4, ruby: "2.1"},
+        )
+      end
+    end
+
+    describe 'github_action_test_matrix' do
+      subject { super()[:github_action_test_matrix] }
+
+      it { is_expected.to be_an_instance_of(Array) }
+      it 'is expected to contain supported os / puppet version combinations' do
+        is_expected.to contain_exactly(
+          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
         )
       end
     end


### PR DESCRIPTION
This is used to avoid running acceptance tests on systems where versions
of Puppet are not supported (yet or anymore).