### PR TITLE
Return empty beaker matrices unless there are tests

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -17,10 +17,16 @@ module PuppetMetadata
       }
     end
 
+    def self.has_acceptance_tests?
+      ENV['PUPPET_METADATA_FORCE_ACCEPTANCE'] || Dir[File.join('spec', 'acceptance', '**', '*_spec.rb')].any?
+    end
+
     private
 
     def beaker_setfiles(use_fqdn, pidfile_workaround)
       setfiles = []
+      return setfiles unless GithubActions.has_acceptance_tests?
+
       metadata.beaker_setfiles(use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround) do |setfile, name|
         setfiles << {
           name: name,
@@ -53,6 +59,8 @@ module PuppetMetadata
     end
 
     def github_action_test_matrix(use_fqdn: false, pidfile_workaround: false)
+      return [] unless GithubActions.has_acceptance_tests?
+
       metadata.operatingsystems.each_with_object([]) do |(os, releases), matrix_include|
         releases&.each do |release|
           puppet_major_versions.each do |puppet_version|

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -42,14 +42,24 @@ describe PuppetMetadata::GithubActions do
     describe 'beaker_setfiles' do
       subject { super()[:beaker_setfiles] }
 
-      it { is_expected.to be_an_instance_of(Array) }
-      it 'is expected to contain CentOS 7 and 8 + Debian 9 and 10' do
-        is_expected.to contain_exactly(
-          {name: "CentOS 7", value: "centos7-64"},
-          {name: "CentOS 8", value: "centos8-64"},
-          {name: "Debian 9", value: "debian9-64"},
-          {name: "Debian 10", value: "debian10-64"},
-        )
+      describe 'without any acceptance test' do
+        before { allow(described_class).to receive(:has_acceptance_tests?).and_return(false).twice }
+
+        it { is_expected.to eq([]) }
+      end
+
+      describe 'with any acceptance test' do
+        before { expect(described_class).to receive(:has_acceptance_tests?).and_return(true).twice }
+
+        it { is_expected.to be_an_instance_of(Array) }
+        it 'is expected to contain CentOS 7 and 8 + Debian 9 and 10' do
+          is_expected.to contain_exactly(
+            {name: "CentOS 7", value: "centos7-64"},
+            {name: "CentOS 8", value: "centos8-64"},
+            {name: "Debian 9", value: "debian9-64"},
+            {name: "Debian 10", value: "debian10-64"},
+          )
+        end
       end
     end
 
@@ -86,60 +96,70 @@ describe PuppetMetadata::GithubActions do
     describe 'github_action_test_matrix' do
       subject { super()[:github_action_test_matrix] }
 
-      it { is_expected.to be_an_instance_of(Array) }
-      it 'is expected to contain supported os / puppet version combinations' do
-        is_expected.to contain_exactly(
-          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
-          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
-          {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
-          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
-          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
-          {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
-          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
-          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
-          {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
-          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
-          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
-          {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
-        )
+      describe 'without any acceptance test' do
+        before { allow(described_class).to receive(:has_acceptance_tests?).and_return(false).twice }
+
+        it { is_expected.to eq([]) }
       end
 
-      context 'when beaker_pidfile_workaround is true' do
-        let(:beaker_pidfile_workaround) { true }
+      describe 'with any acceptance test' do
+        before { expect(described_class).to receive(:has_acceptance_tests?).and_return(true).twice }
 
-        it 'is expected to contain supported os / puppet version combinations with image option' do
+        it { is_expected.to be_an_instance_of(Array) }
+        it 'is expected to contain supported os / puppet version combinations' do
           is_expected.to contain_exactly(
-            {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
+            {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+            {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+            {setfile: {name: "CentOS 7", value: "centos7-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+            {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+            {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+            {setfile: {name: "CentOS 8", value: "centos8-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+            {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
+            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet5", name: "Puppet 5", value: 5}},
+            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet6", name: "Puppet 6", value: 6}},
+            {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {collection: "puppet7", name: "Puppet 7", value: 7}},
           )
         end
-      end
 
-      context 'when beaker_use_fqdn is true' do
-        let(:beaker_use_fqdn) { true }
+        context 'when beaker_pidfile_workaround is true' do
+          let(:beaker_pidfile_workaround) { true }
 
-        it 'is expected to contain supported os / puppet version combinations with hostname option' do
-          is_expected.to contain_exactly(
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
-          )
+          it 'is expected to contain supported os / puppet version combinations with image option' do
+            is_expected.to contain_exactly(
+              {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "CentOS 7", value: "centos7-64{image=centos:7.6.1810}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+              {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "Debian 9", value: "debian9-64"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+              {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "Debian 10", value: "debian10-64"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
+            )
+          end
+        end
+
+        context 'when beaker_use_fqdn is true' do
+          let(:beaker_use_fqdn) { true }
+
+          it 'is expected to contain supported os / puppet version combinations with hostname option' do
+            is_expected.to contain_exactly(
+              {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+              {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+              {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+              {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+              {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+              {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Today there's ERB templating in Vox Pupuli's modulesync config that disables the job. This doesn't work with [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows). This outputs an empty matrix for beaker which prevents running the acceptance tests without having to template the workflow.

It still allows forcing it via an undocumented environment variable (`PUPPET_METADATA_FORCE_ACCEPTANCE`).