### PR TITLE
Add a name to the GHA beaker test matrix

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -81,6 +81,7 @@ module PuppetMetadata
         next if puppet_version_below_minimum?(puppet_version[:value])
 
         matrix_include << {
+          name: "#{puppet_version[:name]} - #{setfile[1]}",
           setfile: {
             name: setfile[1],
             value: setfile[0],

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -44,6 +44,7 @@ describe PuppetMetadata::GithubActions do
     }
   end
 
+  # rubocop:disable Layout/LineLength
   describe 'outputs' do
     subject { super().outputs }
 
@@ -117,25 +118,25 @@ describe PuppetMetadata::GithubActions do
 
       it 'is expected to contain supported os / puppet version combinations' do
         expect(subject).to contain_exactly(
-          { setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-          { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
+          { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
         )
       end
 
@@ -144,21 +145,21 @@ describe PuppetMetadata::GithubActions do
 
         it 'is expected to contain supported os / puppet version combinations excluding puppet 5' do
           expect(subject).to contain_exactly(
-            { setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
+            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
           )
         end
       end
@@ -168,21 +169,21 @@ describe PuppetMetadata::GithubActions do
 
         it 'is expected to contain supported os / puppet version combinations with image option' do
           expect(subject).to contain_exactly(
-            { setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
+            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
           )
         end
       end
@@ -192,28 +193,29 @@ describe PuppetMetadata::GithubActions do
 
         it 'is expected to contain supported os / puppet version combinations with hostname option' do
           expect(subject).to contain_exactly(
-            { setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64{hostname=archlinuxrolling-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64{hostname=archlinuxrolling-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
+            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
           )
         end
       end
     end
   end
+  # rubocop:enable Layout/LineLength
 end


### PR DESCRIPTION
Adding a name means the GHA job can use `${{ matrix.name }}` instead of specific properties. This means `puppet_metadata` is in control of naming jobs instead of the individual action. It opens the path to other tests. For example, beaker supports multiple suites. Those could run as individual entries and reported.