### PR TITLE
Add Arch Linux support

### DIFF
--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -65,7 +65,7 @@ module PuppetMetadata
       # Return whether a Beaker setfile can be generated for the given OS
       # @param [String] os The operating system
       def os_supported?(os)
-        ['CentOS', 'Fedora', 'Debian', 'Ubuntu'].include?(os)
+        ['Archlinux', 'CentOS', 'Fedora', 'Debian', 'Ubuntu'].include?(os)
       end
 
       private

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -56,10 +56,15 @@ module PuppetMetadata
       majors = puppet_major_versions
 
       metadata.operatingsystems.each do |os, releases|
-        releases&.each do |release|
-          majors.each do |puppet_version|
-            if AIO.has_aio_build?(os, release, puppet_version[:value])
-              yield [os, release, puppet_version]
+        case os
+        when 'Archlinux', 'Gentoo'
+          yield [os, 'rolling', majors.max_by { |v| v[:value] }]
+        else
+          releases&.each do |release|
+            majors.each do |puppet_version|
+              if AIO.has_aio_build?(os, release, puppet_version[:value])
+                yield [os, release, puppet_version]
+              end
             end
           end
         end


### PR DESCRIPTION
Alternative to https://github.com/voxpupuli/puppet_metadata/pull/15. I took a slightly different approach by splitting the GHA test matrix (which is wrongly named, it should really be `beaker_test_matrix`) into two functions: one to yield the tuple of OS, release and Puppet version and one to convert that into the actual output.

It doesn't implement it in `beaker_setfiles` but that is now unused and I'd rather deprecate it instead and remove it in a major release.