### PR TITLE
Add expected EOL dates for current FreeBSD releases

### DIFF
--- a/lib/puppet_metadata/operatingsystem.rb
+++ b/lib/puppet_metadata/operatingsystem.rb
@@ -73,8 +73,8 @@ module PuppetMetadata
       },
       # https://endoflife.software/operating-systems/unix-like-bsd/freebsd
       'FreeBSD' => {
-        '13' => nil,
-        '12' => nil,
+        '13' => '2026-01-31',
+        '12' => '2024-06-30',
         '11' => '2021-09-30',
         '10' => '2018-10-31',
         '9' => '2016-12-31',


### PR DESCRIPTION
As suggested by @ekohl in https://github.com/voxpupuli/puppet_metadata/pull/43#discussion_r904279039