### PR TITLE
Update Ubuntu metadata

### DIFF
--- a/lib/puppet_metadata/aio.rb
+++ b/lib/puppet_metadata/aio.rb
@@ -46,7 +46,7 @@ module PuppetMetadata
         '16.04' => 5..7,
         '18.04' => 5..7,
         '20.04' => 6..7,
-        '22.04' => [], # https://tickets.puppetlabs.com/browse/PA-4233
+        '22.04' => 6..7,
       },
     }.freeze
 

--- a/spec/operatingsystem_spec.rb
+++ b/spec/operatingsystem_spec.rb
@@ -30,8 +30,8 @@ describe PuppetMetadata::OperatingSystem do
     context 'with Ubuntu' do
       let(:os) { 'Ubuntu' }
 
-      it 'returns 18.04, 20.04, 21.10 and 22.04' do
-        expect(described_class.supported_releases(os)).to match_array(['18.04', '20.04', '21.10', '22.04'])
+      it 'returns 18.04, 20.04 and 22.04' do
+        expect(described_class.supported_releases(os)).to match_array(['18.04', '20.04', '22.04'])
       end
 
       it 'the last entry matches latest_release' do


### PR DESCRIPTION
- Ubuntu 21.10 has reached EOL
- Puppetlabs now ship Puppet AIO packages for Jammy
