### PR TITLE
Add --minimum-major-puppet-version option

### DIFF
--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -5,7 +5,13 @@ require 'puppet_metadata'
 
 PidfileWorkaround = Object.new
 
-options = {}
+options = {
+  beaker_use_fqdn: false,
+  beaker_pidfile_workaround: false,
+  domain: nil,
+  minimum_major_puppet_version: nil
+}
+
 OptionParser.new do |opts|
   opts.accept(PidfileWorkaround) do |value|
     case value
@@ -20,10 +26,11 @@ OptionParser.new do |opts|
 
   opts.banner = "Usage: #{$0} [options] metadata"
 
-  opts.on("--[no-]use-fqdn", "Generate beaker setfiles with a FQDN")
-  opts.on("--pidfile-workaround VALUE", "Generate the systemd PIDFile workaround to work around a docker bug", PidfileWorkaround)
-  opts.on("-d", "--domain VALUE", "the domain for the box, only used when --use-fqdn is set to true")
-end.parse!(into: options)
+  opts.on("--[no-]use-fqdn", "Generate beaker setfiles with a FQDN") { |opt| options[:beaker_use_fqdn] = opt }
+  opts.on("--pidfile-workaround VALUE", "Generate the systemd PIDFile workaround to work around a docker bug", PidfileWorkaround) { |opt| options[:beaker_pidfile_workaround] = opt }
+  opts.on("-d", "--domain VALUE", "the domain for the box, only used when --use-fqdn is set to true") { |opt| options[:domain] = opt }
+  opts.on("--minimum-major-puppet-version VERSION", "Don't create actions for Puppet versions less than this major version") { |opt| options[:minimum_major_puppet_version] = opt }
+end.parse!
 
 filename = ARGV[0]
 if filename.nil? || filename.empty?
@@ -38,7 +45,7 @@ rescue StandardError => e
 end
 
 github_output = !ENV['GITHUB_OUTPUT'].nil? ? File.open(ENV['GITHUB_OUTPUT'], 'a') : $stdout
-metadata.github_actions.outputs(beaker_use_fqdn: options[:'use-fqdn'], beaker_pidfile_workaround: options[:'pidfile-workaround'], domain: options[:'domain']).each do |name, value|
+metadata.github_actions(options).outputs.each do |name, value|
   github_output.write("#{name}=#{value.to_json}\n")
 end
 github_output.close

--- a/lib/puppet_metadata/metadata.rb
+++ b/lib/puppet_metadata/metadata.rb
@@ -182,9 +182,10 @@ module PuppetMetadata
       matches?(dependencies[name], version)
     end
 
+    # @param [Hash] options A hash containing the command line options
     # @return [PuppetMetadata::GithubActions] A GithubActions instance
-    def github_actions
-      PuppetMetadata::GithubActions.new(self)
+    def github_actions(options)
+      PuppetMetadata::GithubActions.new(self, options)
     end
 
     # @param [Boolean] use_fqdn


### PR DESCRIPTION
This is an alternative to https://github.com/voxpupuli/puppet_metadata/pull/58

The options become an instance variable of `GithubActions` removing the need to pass individual options around between the various private methods.  Simpler to me, but not sure if this is the 'right way'.