### PR TITLE
Beaker jobs: correct generated setfiles

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -13,7 +13,7 @@ module PuppetMetadata
         beaker_setfiles: beaker_setfiles(beaker_use_fqdn, beaker_pidfile_workaround, domain),
         puppet_major_versions: puppet_major_versions,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
-        github_action_test_matrix: github_action_test_matrix(use_fqdn: beaker_use_fqdn, pidfile_workaround: beaker_pidfile_workaround),
+        github_action_test_matrix: github_action_test_matrix(use_fqdn: beaker_use_fqdn, pidfile_workaround: beaker_pidfile_workaround, domain: domain),
       }
     end
 
@@ -71,11 +71,11 @@ module PuppetMetadata
       end
     end
 
-    def github_action_test_matrix(use_fqdn: false, pidfile_workaround: false)
+    def github_action_test_matrix(use_fqdn: false, pidfile_workaround: false, domain: nil)
       matrix_include = []
 
       beaker_os_releases do |os, release, puppet_version|
-        setfile = PuppetMetadata::Beaker.os_release_to_setfile(os, release, use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround)
+        setfile = PuppetMetadata::Beaker.os_release_to_setfile(os, release, use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround, domain: domain)
         next unless setfile
 
         matrix_include << {


### PR DESCRIPTION
Without the change, the output looks like this:

```
$ bundle exec metadata2gha --domain foo.example.com --pidfile-workaround true metadata.json
beaker_setfiles=[{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"}]
puppet_major_versions=[{"name":"Puppet 7","value":7,"collection":"puppet7"},{"name":"Puppet 6","value":6,"collection":"puppet6"}]
puppet_unit_test_matrix=[{"puppet":7,"ruby":"2.7"},{"puppet":6,"ruby":"2.5"}]
github_action_test_matrix=[{"setfile":{"name":"CentOS 7","value":"centos7-64{image=centos:7.6.1810}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"CentOS 7","value":"centos7-64{image=centos:7.6.1810}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 10","value":"debian10-64"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 10","value":"debian10-64"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 11","value":"debian11-64"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 11","value":"debian11-64"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}}]
```

And with the change:

```
$ bundle exec metadata2gha --domain foo.example.com --pidfile-workaround true metadata.json
beaker_setfiles=[{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"}]
puppet_major_versions=[{"name":"Puppet 7","value":7,"collection":"puppet7"},{"name":"Puppet 6","value":6,"collection":"puppet6"}]
puppet_unit_test_matrix=[{"puppet":7,"ruby":"2.7"},{"puppet":6,"ruby":"2.5"}]
github_action_test_matrix=[{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}}]
```

Our CI setup currently doesn't even use beaker_setfiles, we're only using github_action_test_matrix: https://github.com/voxpupuli/gha-puppet/blob/a3c2a01493284b126a3d742d42766cafd2904ec7/.github/workflows/beaker.yml#L123