### PR TITLE
beaker: append puppet version to hostname

### DIFF
--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -38,17 +38,20 @@ module PuppetMetadata
       #   it's applied only when os is included in the provided array.
       # @param [Optional[String]] domain
       #   Enforce a domain to be appended to the hostname, making it an FQDN
+      # @param [Optional[String]] puppet_version
+      #   The desired puppet version. Will be appended to the hostname
       #
       # @return [nil] If no setfile is available
       # @return [Array<(String, String)>] The beaker setfile description with a readable name
-      def os_release_to_setfile(os, release, use_fqdn: false, pidfile_workaround: false, domain: nil)
+      def os_release_to_setfile(os, release, use_fqdn: false, pidfile_workaround: false, domain: nil, puppet_version: nil)
         return unless os_supported?(os)
 
         name = "#{os.downcase}#{release.tr('.', '')}-64"
+        hostname = puppet_version != nil ? "#{name}-#{puppet_version}" : name
         domain ||= 'example.com' if use_fqdn
 
         options = {}
-        options[:hostname] = "#{name}.#{domain}" if domain
+        options[:hostname] = "#{hostname}.#{domain}" if domain
 
         # Docker messes up cgroups and some systemd versions can't deal with
         # that when PIDFile is used.

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -83,7 +83,7 @@ module PuppetMetadata
 
       beaker_os_releases do |os, release, puppet_version|
         setfile = PuppetMetadata::Beaker.os_release_to_setfile(
-          os, release, use_fqdn: options[:beaker_use_fqdn], pidfile_workaround: options[:beaker_pidfile_workaround], domain: options[:domain]
+          os, release, use_fqdn: options[:beaker_use_fqdn], pidfile_workaround: options[:beaker_pidfile_workaround], domain: options[:domain], puppet_version: puppet_version[:collection]
         )
         next unless setfile
         next if puppet_version_below_minimum?(puppet_version[:value])

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -184,20 +184,20 @@ describe PuppetMetadata::GithubActions do
 
         it 'is expected to contain supported os / puppet version combinations with hostname option' do
           is_expected.to contain_exactly(
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "CentOS 9", value: "centos9-64{hostname=centos9-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "CentOS 9", value: "centos9-64{hostname=centos9-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
-            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
+            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64-puppet7.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64-puppet6.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+            {setfile: {name: "CentOS 7", value: "centos7-64{hostname=centos7-64-puppet5.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64-puppet7.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64-puppet6.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+            {setfile: {name: "CentOS 8", value: "centos8-64{hostname=centos8-64-puppet5.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+            {setfile: {name: "CentOS 9", value: "centos9-64{hostname=centos9-64-puppet7.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+            {setfile: {name: "CentOS 9", value: "centos9-64{hostname=centos9-64-puppet6.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64-puppet7.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64-puppet6.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+            {setfile: {name: "Debian 9", value: "debian9-64{hostname=debian9-64-puppet5.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}},
+            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64-puppet7.example.com}"}, puppet: {name: "Puppet 7", value: 7, collection: "puppet7"}},
+            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64-puppet6.example.com}"}, puppet: {name: "Puppet 6", value: 6, collection: "puppet6"}},
+            {setfile: {name: "Debian 10", value: "debian10-64{hostname=debian10-64-puppet5.example.com}"}, puppet: {name: "Puppet 5", value: 5, collection: "puppet5"}}
           )
         end
       end


### PR DESCRIPTION
This will ensure that a single CI run creates unique hostnames. Before:

```
$ bundle exec metadata2gha --domain foo.example.com --pidfile-workaround true metadata.json
beaker_setfiles=[{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"}]
puppet_major_versions=[{"name":"Puppet 7","value":7,"collection":"puppet7"},{"name":"Puppet 6","value":6,"collection":"puppet6"}]
puppet_unit_test_matrix=[{"puppet":7,"ruby":"2.7"},{"puppet":6,"ruby":"2.5"}]
github_action_test_matrix=[{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.foo.example.com,image=centos:7.6.1810}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.foo.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}}]
```

And with this change:
```
$ bundle exec metadata2gha metadata.json --domain example.com

beaker_setfiles=[{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64.example.com}"},{"name":"CentOS 8","value":"centos8-64{hostname=centos8-64.example.com}"},{"name":"Debian 10","value":"debian10-64{hostname=debian10-64.example.com}"},{"name":"Debian 11","value":"debian11-64{hostname=debian11-64.example.com}"},{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64.example.com}"},{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64.example.com}"}]
puppet_major_versions=[{"name":"Puppet 7","value":7,"collection":"puppet7"},{"name":"Puppet 6","value":6,"collection":"puppet6"}]
puppet_unit_test_matrix=[{"puppet":7,"ruby":"2.7"},{"puppet":6,"ruby":"2.5"}]
github_action_test_matrix=[{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"CentOS 7","value":"centos7-64{hostname=centos7-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"CentOS 8","value":"centos8-64{hostname=centos8-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"CentOS 8","value":"centos8-64{hostname=centos8-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 10","value":"debian10-64{hostname=debian10-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 11","value":"debian11-64{hostname=debian11-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 18.04","value":"ubuntu1804-64{hostname=ubuntu1804-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64-puppet7.example.com}"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Ubuntu 20.04","value":"ubuntu2004-64{hostname=ubuntu2004-64-puppet6.example.com}"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}}]
```

On purpose, we only modify github_action_test_matrix, not beaker_setfiles. Because beaker_setfiles is not Puppet Version aware and contains only one Setfile per OS version, not one (per OS)*(per Puppet version)

Contains also https://github.com/voxpupuli/puppet_metadata/pull/64