### PR TITLE
Drop unused beaker_setfiles output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,31 +16,8 @@ To get outputs [usable in Github Actions](https://docs.github.com/en/free-pro-te
 
 ```console
 $ metadata2gha-beaker
-beaker_setfiles=[{"name":"CentOS 7","value":"centos7-64"},{"name":"CentOS 8","value":"centos8-64"},{"name":"Debian 10","value":"debian10-64"},{"name":"Ubuntu 18.04","value":"ubuntu1804-64"}]
 puppet_major_versions=[{"name":"Puppet 6","value":6,"collection":"puppet6"},{"name":"Puppet 5","value":5,"collection":"puppet5"}]
 puppet_unit_test_matrix=[{"puppet":6,"ruby":"2.5"},{"puppet":5,"ruby":"2.4"}]
-```
-
-Beaker setfiles formatted for readability:
-```json
-[
-  {
-    "name": "CentOS 7",
-    "value": "centos7-64"
-  },
-  {
-    "name": "CentOS 8",
-    "value": "centos8-64"
-  },
-  {
-    "name": "Debian 10",
-    "value": "debian10-64"
-  },
-  {
-    "name": "Ubuntu 18.04",
-    "value": "ubuntu1804-64"
-  }
-]
 ```
 
 Puppet major versions formatted for readability:

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -13,7 +13,6 @@ module PuppetMetadata
     # @return [Hash[Symbol, Any]] The outputs for Github Actions
     def outputs
       {
-        beaker_setfiles: beaker_setfiles,
         puppet_major_versions: puppet_major_versions,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
         github_action_test_matrix: github_action_test_matrix,
@@ -21,18 +20,6 @@ module PuppetMetadata
     end
 
     private
-
-
-    def beaker_setfiles
-      setfiles = []
-      metadata.beaker_setfiles(use_fqdn: options[:beaker_use_fqdn], pidfile_workaround: options[:beaker_pidfile_workaround], domain: options[:domain]) do |setfile, name|
-        setfiles << {
-          name: name,
-          value: setfile,
-        }
-      end
-      setfiles
-    end
 
     def puppet_major_versions
       metadata.puppet_major_versions.sort.reverse.map do |version|

--- a/lib/puppet_metadata/metadata.rb
+++ b/lib/puppet_metadata/metadata.rb
@@ -188,25 +188,6 @@ module PuppetMetadata
       PuppetMetadata::GithubActions.new(self, options)
     end
 
-    # @param [Boolean] use_fqdn
-    #   Whether to set the hostname to a fully qualified domain name (deprecated, use domain)
-    # @param [Boolean] pidfile_workaround
-    #   Whether to apply the Docker pidfile workaround
-    # @param [String] domain
-    #   Enforce a domain to be appended to the hostname, making it an FQDN
-    # @yieldparam [String] setfile
-    #   The supported setfile configurations
-    # @see PuppetMetadata::Beaker#os_release_to_setfile
-    def beaker_setfiles(use_fqdn: false, pidfile_workaround: false, domain: nil)
-      operatingsystems.each do |os, releases|
-        next unless PuppetMetadata::Beaker.os_supported?(os)
-        releases&.each do |release|
-          setfile = PuppetMetadata::Beaker.os_release_to_setfile(os, release, use_fqdn: use_fqdn, pidfile_workaround: pidfile_workaround, domain: domain)
-          yield setfile if setfile
-        end
-      end
-    end
-
     private
 
     def build_version_requirement_hash(array)

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -47,22 +47,7 @@ describe PuppetMetadata::GithubActions do
     subject { super().outputs }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:beaker_setfiles, :puppet_major_versions, :puppet_unit_test_matrix, :github_action_test_matrix) }
-
-    describe 'beaker_setfiles' do
-      subject { super()[:beaker_setfiles] }
-
-      it { is_expected.to be_an_instance_of(Array) }
-      it 'is expected to contain CentOS 7, 8 and 9 + Debian 9 and 10' do
-        is_expected.to contain_exactly(
-          {name: "CentOS 7", value: "centos7-64"},
-          {name: "CentOS 8", value: "centos8-64"},
-          {name: "CentOS 9", value: "centos9-64"},
-          {name: "Debian 9", value: "debian9-64"},
-          {name: "Debian 10", value: "debian10-64"},
-        )
-      end
-    end
+    it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :github_action_test_matrix) }
 
     describe 'puppet_major_versions' do
       subject { super()[:puppet_major_versions] }

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -29,7 +29,6 @@ describe PuppetMetadata::Metadata do
       its(:operatingsystems) { is_expected.to eq({}) }
       it { expect(subject.os_release_supported?('any', 'version')).to be(true) }
       it { expect(subject.eol_operatingsystems).to eq({}) }
-      specify { expect { |b| subject.beaker_setfiles(&b) }.not_to yield_control }
       it { expect { subject.puppet_major_versions }.to raise_error(/No Puppet requirement found/) }
     end
 
@@ -178,55 +177,6 @@ describe PuppetMetadata::Metadata do
 
         it 'with puppetlabs/concat 7.0.0' do
           expect(subject.satisfies_dependency?('puppetlabs/concat', '7.0.0')).to be(false)
-        end
-      end
-
-      describe 'beaker_setfiles' do
-        it 'works without arguments' do
-          expected = [
-            ['centos7-64', 'CentOS 7'],
-            ['centos8-64', 'CentOS 8'],
-            ['centos9-64', 'CentOS 9'],
-            ['debian9-64', 'Debian 9'],
-            ['debian10-64', 'Debian 10'],
-            ['ubuntu1404-64', 'Ubuntu 14.04'],
-            ['ubuntu1604-64', 'Ubuntu 16.04'],
-            ['ubuntu1804-64', 'Ubuntu 18.04'],
-            ['ubuntu2004-64', 'Ubuntu 20.04'],
-            ['ubuntu2204-64', 'Ubuntu 22.04'],
-          ]
-          expect { |b| subject.beaker_setfiles(&b) }.to yield_successive_args(*expected)
-        end
-
-        it 'works when using use_fqdn' do
-          expected = [
-            ['centos7-64{hostname=centos7-64.example.com}', 'CentOS 7'],
-            ['centos8-64{hostname=centos8-64.example.com}', 'CentOS 8'],
-            ['centos9-64{hostname=centos9-64.example.com}', 'CentOS 9'],
-            ['debian9-64{hostname=debian9-64.example.com}', 'Debian 9'],
-            ['debian10-64{hostname=debian10-64.example.com}', 'Debian 10'],
-            ['ubuntu1404-64{hostname=ubuntu1404-64.example.com}', 'Ubuntu 14.04'],
-            ['ubuntu1604-64{hostname=ubuntu1604-64.example.com}', 'Ubuntu 16.04'],
-            ['ubuntu1804-64{hostname=ubuntu1804-64.example.com}', 'Ubuntu 18.04'],
-            ['ubuntu2004-64{hostname=ubuntu2004-64.example.com}', 'Ubuntu 20.04'],
-            ['ubuntu2204-64{hostname=ubuntu2204-64.example.com}', 'Ubuntu 22.04'],
-          ]
-          expect { |b| subject.beaker_setfiles(use_fqdn: true, &b) }.to yield_successive_args(*expected)
-        end
-
-        it 'works when passing pidfile_workaround' do
-          expected = [
-            ['centos7-64{image=centos:7.6.1810}', 'CentOS 7'],
-            ['centos9-64', 'CentOS 9'],
-            ['debian9-64', 'Debian 9'],
-            ['debian10-64', 'Debian 10'],
-            ['ubuntu1404-64', 'Ubuntu 14.04'],
-            ['ubuntu1604-64{image=ubuntu:xenial-20191212}', 'Ubuntu 16.04'],
-            ['ubuntu1804-64', 'Ubuntu 18.04'],
-            ['ubuntu2004-64', 'Ubuntu 20.04'],
-            ['ubuntu2204-64', 'Ubuntu 22.04'],
-          ]
-          expect { |b| subject.beaker_setfiles(pidfile_workaround: true, &b) }.to yield_successive_args(*expected)
         end
       end
     end


### PR DESCRIPTION
A long long time ago, this was used. It's not required anymore, so we can drop it.