### PR TITLE
pin CI runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install libyaml-dev for Psych 5.0+
         run: sudo apt-get install -y libyaml-dev
+      - name: update rubygems
+        run: sudo gem update --system
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
to test if ruby 2.5 passes again