### PR TITLE
rspec: print full diff for hashes

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,3 +25,11 @@ end
 require 'rspec/core'
 require 'rspec/its'
 require 'puppet_metadata'
+
+# copied from https://stackoverflow.com/a/74965697
+# tell rspec to not shorten the diff between what it expects and what it got
+RSpec.configure do |rspec|
+  rspec.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+end


### PR DESCRIPTION
We compare a lot of hashes. rspec has the option to print what it expected, what it got, what's missing and what's there but not supposed to be there. That's quite helpful. By default the output is truncated. We need to untruncate it.