### PR TITLE
CI: Dont install libyaml-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
       COVERAGE: ${{ matrix.coverage }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install libyaml-dev for Psych 5.0+
-        run: sudo apt-get install -y libyaml-dev
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This was required in the past. I don't know why, and the package is now included in the Ubuntu 22.04 runner anyways.