### PR TITLE
Add support for Fedora Distro Puppet testing

### DIFF
--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -63,8 +63,10 @@ module PuppetMetadata
         else
           releases&.each do |release|
             majors.each do |puppet_version|
-              if AIO.has_aio_build?(os, release, puppet_version[:value]) # rubocop:disable Style/IfUnlessModifier
+              if AIO.has_aio_build?(os, release, puppet_version[:value])
                 yield [os, release, puppet_version]
+              elsif PuppetMetadata::OperatingSystem.os_release_puppet_version(os, release) == puppet_version[:value]
+                yield [os, release, distro_puppet_version.merge(value: puppet_version[:value])]
               end
             end
           end

--- a/lib/puppet_metadata/operatingsystem.rb
+++ b/lib/puppet_metadata/operatingsystem.rb
@@ -206,6 +206,28 @@ module PuppetMetadata
         releases.select { |_release, eol_date| !eol_date || Date.parse(eol_date) > today }.keys
                 .sort_by { |release| Gem::Version.new(release) }
       end
+
+      # Return the Puppet major version in an OS release, if any
+      #
+      # Only tracks releases without an AIO build, since that's preferred.
+      #
+      # @param [String] operatingsystem
+      #   The operating system name
+      # @param [String] release
+      #   The operating system release version
+      #
+      # @return [Optional[Integer]] The Puppet major version, if any
+      def os_release_puppet_version(operatingsystem, release)
+        case operatingsystem
+        when 'Fedora'
+          case release
+          when '39', '40'
+            8
+          when '37', '38'
+            7
+          end
+        end
+      end
     end
   end
 end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -40,11 +40,15 @@ describe PuppetMetadata::GithubActions do
           operatingsystem: 'Debian',
           operatingsystemrelease: %w[9 10],
         },
+        {
+          operatingsystem: 'Fedora',
+          operatingsystemrelease: %w[36 38 40],
+        },
       ],
     }
   end
 
-  # rubocop:disable Layout/LineLength
+  # rubocop:disable Layout/LineLength,RSpec/ExampleLength
   describe 'outputs' do
     subject { super().outputs }
 
@@ -137,6 +141,10 @@ describe PuppetMetadata::GithubActions do
           { name: 'Puppet 6 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian10-64' } },
           { name: 'Puppet 7 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian10-64' } },
           { name: 'Puppet 8 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian10-64' } },
+          { name: 'Puppet 7 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'fedora36-64' } },
+          { name: 'Puppet 8 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'fedora36-64' } },
+          { name: 'Distro Puppet - Fedora 38', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'fedora38-64' } },
+          { name: 'Distro Puppet - Fedora 40', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'fedora40-64' } },
         )
       end
 
@@ -178,6 +186,10 @@ describe PuppetMetadata::GithubActions do
           { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
           { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
           { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
+          { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
         )
       end
 
@@ -201,6 +213,10 @@ describe PuppetMetadata::GithubActions do
             { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
             { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
             { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
+            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
         end
       end
@@ -225,6 +241,10 @@ describe PuppetMetadata::GithubActions do
             { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
             { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
             { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
+            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
         end
       end
@@ -253,10 +273,14 @@ describe PuppetMetadata::GithubActions do
             { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
             { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
             { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7.example.com}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8.example.com}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64{hostname=fedora38-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
+            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64{hostname=fedora40-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
         end
       end
     end
   end
-  # rubocop:enable Layout/LineLength
+  # rubocop:enable Layout/LineLength,RSpec/ExampleLength
 end


### PR DESCRIPTION
When there is no AIO build available, it is possible to test the OS using the distribution provided package.

Since these aren't rolling releases, it includes the Puppet version in the context. Not in the name, to keep it consistent.