### PR TITLE
Support BEAKER_FACTER_* env vars in beaker testing

### DIFF
--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -10,6 +10,7 @@ options = {
   beaker_pidfile_workaround: false,
   domain: nil,
   minimum_major_puppet_version: nil,
+  beaker_fact: nil,
 }
 
 OptionParser.new do |opts|
@@ -30,6 +31,15 @@ OptionParser.new do |opts|
   opts.on('--pidfile-workaround VALUE', 'Generate the systemd PIDFile workaround to work around a docker bug', PidfileWorkaround) { |opt| options[:beaker_pidfile_workaround] = opt }
   opts.on('-d', '--domain VALUE', 'the domain for the box, only used when --use-fqdn is set to true') { |opt| options[:domain] = opt }
   opts.on('--minimum-major-puppet-version VERSION', "Don't create actions for Puppet versions less than this major version") { |opt| options[:minimum_major_puppet_version] = opt }
+  opts.on('--beaker-facter FACT:LABEL:VALUES', 'Expand the matrix based on a fact. Separate values using commas') do |opt|
+    if opt != 'false'
+      fact, label, values = opt.split(':', 3)
+      label = fact if !label || label.empty?
+      raise OptionParser::InvalidArgument unless values
+
+      options[:beaker_facter] = [fact, label, values.split(',')]
+    end
+  end
 end.parse!
 
 filename = ARGV[0]

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -74,9 +74,7 @@ module PuppetMetadata
       matrix_include = []
 
       beaker_os_releases do |os, release, puppet_version|
-        setfile = PuppetMetadata::Beaker.os_release_to_setfile(
-          os, release, use_fqdn: options[:beaker_use_fqdn], pidfile_workaround: options[:beaker_pidfile_workaround], domain: options[:domain], puppet_version: puppet_version[:collection]
-        )
+        setfile = os_release_to_beaker_setfile(os, release, puppet_version[:collection])
         next unless setfile
         next if puppet_version_below_minimum?(puppet_version[:value])
 
@@ -97,6 +95,17 @@ module PuppetMetadata
       return false unless version && options[:minimum_major_puppet_version]
 
       Gem::Version.new(version) < Gem::Version.new(options[:minimum_major_puppet_version])
+    end
+
+    def os_release_to_beaker_setfile(os, release, puppet_collection)
+      PuppetMetadata::Beaker.os_release_to_setfile(
+        os,
+        release,
+        use_fqdn: options[:beaker_use_fqdn],
+        pidfile_workaround: options[:beaker_pidfile_workaround],
+        domain: options[:domain],
+        puppet_version: puppet_collection,
+      )
     end
   end
 end

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -74,9 +74,10 @@ module PuppetMetadata
       matrix_include = []
 
       beaker_os_releases do |os, release, puppet_version|
+        next if puppet_version_below_minimum?(puppet_version[:value])
+
         setfile = os_release_to_beaker_setfile(os, release, puppet_version[:collection])
         next unless setfile
-        next if puppet_version_below_minimum?(puppet_version[:value])
 
         matrix_include << {
           name: "#{puppet_version[:name]} - #{setfile[1]}",

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -87,10 +87,20 @@ module PuppetMetadata
           'BEAKER_SETFILE' => setfile[0],
         }
 
-        matrix_include << {
-          name: name,
-          env: env,
-        }
+        if options[:beaker_facter]
+          fact, label, values = options[:beaker_facter]
+          values.each do |value|
+            matrix_include << {
+              name: "#{name} - #{label || fact} #{value}",
+              env: env.merge("BEAKER_FACTER_#{fact}" => value),
+            }
+          end
+        else
+          matrix_include << {
+            name: name,
+            env: env,
+          }
+        end
       end
 
       matrix_include

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -14,6 +14,8 @@ module PuppetMetadata
       {
         puppet_major_versions: puppet_major_versions,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
+        puppet_beaker_test_matrix: puppet_beaker_test_matrix,
+        # Deprecated
         github_action_test_matrix: github_action_test_matrix,
       }
     end
@@ -68,6 +70,30 @@ module PuppetMetadata
           end
         end
       end
+    end
+
+    def puppet_beaker_test_matrix
+      matrix_include = []
+
+      beaker_os_releases do |os, release, puppet_version|
+        next if puppet_version_below_minimum?(puppet_version[:value])
+
+        setfile = os_release_to_beaker_setfile(os, release, puppet_version[:collection])
+        next unless setfile
+
+        name = "#{puppet_version[:name]} - #{setfile[1]}"
+        env = {
+          'BEAKER_PUPPET_COLLECTION' => puppet_version[:collection],
+          'BEAKER_SETFILE' => setfile[0],
+        }
+
+        matrix_include << {
+          name: name,
+          env: env,
+        }
+      end
+
+      matrix_include
     end
 
     def github_action_test_matrix

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -139,6 +139,17 @@ describe PuppetMetadata::GithubActions do
           { name: 'Puppet 8 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian10-64' } },
         )
       end
+
+      context 'with beaker_facter option' do
+        let(:options) { super().merge(beaker_facter: ['pulpcore_version', 'Pulp', %w[2 3]]) }
+
+        it 'is expected to contain supported os / puppet version / fact combinations' do
+          expect(subject).to include(
+            { name: 'Distro Puppet - Archlinux rolling - Pulp 2', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64', 'BEAKER_FACTER_pulpcore_version' => '2' } },
+            { name: 'Distro Puppet - Archlinux rolling - Pulp 3', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64', 'BEAKER_FACTER_pulpcore_version' => '3' } },
+          )
+        end
+      end
     end
 
     describe 'github_action_test_matrix' do

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -52,7 +52,7 @@ describe PuppetMetadata::GithubActions do
     let(:beaker_use_fqdn) { false }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :github_action_test_matrix) }
+    it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :puppet_beaker_test_matrix, :github_action_test_matrix) }
 
     describe 'puppet_major_versions' do
       subject { super()[:puppet_major_versions] }
@@ -108,6 +108,36 @@ describe PuppetMetadata::GithubActions do
             { puppet: 6, ruby: '2.5' },
           )
         end
+      end
+    end
+
+    describe 'puppet_beaker_test_matrix' do
+      subject { super()[:puppet_beaker_test_matrix] }
+
+      it { is_expected.to be_an_instance_of(Array) }
+
+      it 'is expected to contain supported os / puppet version combinations' do
+        expect(subject).to contain_exactly(
+          { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64' } },
+          { name: 'Puppet 5 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos7-64' } },
+          { name: 'Puppet 6 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos7-64' } },
+          { name: 'Puppet 7 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos7-64' } },
+          { name: 'Puppet 8 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos7-64' } },
+          { name: 'Puppet 5 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos8-64' } },
+          { name: 'Puppet 6 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos8-64' } },
+          { name: 'Puppet 7 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos8-64' } },
+          { name: 'Puppet 8 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos8-64' } },
+          { name: 'Puppet 6 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos9-64' } },
+          { name: 'Puppet 7 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos9-64' } },
+          { name: 'Puppet 8 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos9-64' } },
+          { name: 'Puppet 5 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian9-64' } },
+          { name: 'Puppet 6 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian9-64' } },
+          { name: 'Puppet 7 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian9-64' } },
+          { name: 'Puppet 5 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian10-64' } },
+          { name: 'Puppet 6 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian10-64' } },
+          { name: 'Puppet 7 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian10-64' } },
+          { name: 'Puppet 8 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian10-64' } },
+        )
       end
     end
 


### PR DESCRIPTION
This PR changes things so you can run a test matrix by providing an additional fact.

The use case is that you have a test suite for your software and want to support multiple versions of that software. For example, in puppet-pulpcore there are versions 3.21, 3.22 and 3.28 supported at the same time. Rather than designing the test suite to first test x, then y and then z while cleaning up in between, this allows providing the version as a fact (so `setup_acceptance_node.rb` can set up repos). You then expand the test matrix. It also includes the version number so it's easy to see which version of the software is being tested. That it can use parallelism for this is just a side effect, but a nice one.

To make it more flexible the config for GHA is changed by providing `puppet_beaker_test_matrix`. This only provides a name and a set of environment variables. This means other CI systems could also use this.

Only a single fact can be provided. Generating the whole matrix was too complex and not needed for my use case. Because it's only providing a name and a set of env vars, it could be extended in the future.

Right now it doesn't have documentation, which should be added before it's merged but this at least allows for review.