### PR TITLE
Add option to generate setfile with multiple hosts and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,16 @@ This results in the following JSON data
 ]
 ```
 
-If you need multiple hosts in your integration tests this could be achived by using the --beaker_nodes_and_roles option
+If you need custom hostname or multiple hosts in your integration tests this could be achived by using the --beaker-hosts option
 
-Option argument is '#HOST:ROLE,ROLE,...;#HOST:..;..' where
+Option argument is 'HOSTNAME:ROLES;HOSTNAME:..;..' where
 - hosts are separated by ';'
 - host number and roles are separated by ':'
-- Roles are separated by ','
+- Roles follow beaker-hostgenerator syntax
 If you don't need any extra roles use '1;2;..'
 
-The 'master' and 'agent' roles will be automatically added to the first host.
-The 'agent' role will be automatically added to the rest.
-
 ```console
-$ metadata2gha --beaker_nodes_and_roles '1:role1,other1;2:role2,other2'
+$ metadata2gha --beaker-hosts 'foo:primary.ma;bar:secondary.a'
 ```
 
 This results in the following JSON data
@@ -126,7 +123,7 @@ This results in the following JSON data
     "name": "Puppet 7 - Debian 12",
     "env": {
       "BEAKER_PUPPET_COLLECTION": "puppet7",
-      "BEAKER_SETFILE": "debian12-64role1,other1.ma{hostname=debian12-64-puppet7-1}-debian12-64role2,other2.a{hostname=debian12-64-puppet7-2}"
+      "BEAKER_SETFILE": "debian12-64primary.ma{hostname=foo-puppet7}-debian12-64secondary.a{hostname=bar-puppet7}"
     }
   }
 ]

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ To get outputs [usable in Github Actions](https://docs.github.com/en/free-pro-te
 
 ```console
 $ metadata2gha
-puppet_major_versions=[{"name":"Puppet 7","value":7,"collection":"puppet7"},{"name":"Puppet 6","value":6,"collection":"puppet6"}]
-puppet_unit_test_matrix=[{"puppet":7,"ruby":"2.7"},{"puppet":6,"ruby":"2.5"}]
-github_action_test_matrix=[{"setfile":{"name":"Debian 11","value":"debian11-64"},"puppet":{"name":"Puppet 7","value":7,"collection":"puppet7"}},{"setfile":{"name":"Debian 11","value":"debian11-64"},"puppet":{"name":"Puppet 6","value":6,"collection":"puppet6"}}]
+puppet_major_versions=[{"name":"Puppet 8","value":8,"collection":"puppet8"},{"name":"Puppet 7","value":7,"collection":"puppet7"}]
+puppet_unit_test_matrix=[{"puppet":8,"ruby":"3.2"},{"puppet":7,"ruby":"2.7"}]
+puppet_beaker_test_matrix=[{"name":"Puppet 8 - Debian 12","env":{"BEAKER_PUPPET_COLLECTION":"puppet8","BEAKER_SETFILE":"debian12-64{hostname=debian12-64-puppet8}"}},{"name":"Puppet 7 - Debian 12","env":{"BEAKER_PUPPET_COLLECTION":"puppet7","BEAKER_SETFILE":"debian12-64{hostname=debian12-64-puppet7}"}}]
 ```
 
 Puppet major versions formatted for readability:
 ```json
 [
   {
+    "name": "Puppet 8",
+    "value": 8,
+    "collection": "puppet8"
+  },
+  {
     "name": "Puppet 7",
     "value": 7,
     "collection": "puppet7"
-  },
-  {
-    "name": "Puppet 6",
-    "value": 6,
-    "collection": "puppet6"
   }
 ]
 ```
@@ -41,45 +41,37 @@ Puppet unit test matrix formatted for readability:
 ```json
 [
   {
-    "puppet": 7,
-    "ruby": "2.7"
+    "puppet": 8,
+    "ruby": "3.2"
   },
   {
-    "puppet": 6,
-    "ruby": "2.5"
+    "puppet": 7,
+    "ruby": "2.7"
   }
 ]
 ```
 
-GitHub Action test matrix formatted for readability
+Beaker test matrix formatted for readability
 ```json
 [
   {
-    "setfile": {
-      "name": "Debian 11",
-      "value": "debian11-64"
-    },
-    "puppet": {
-      "name": "Puppet 7",
-      "value": 7,
-      "collection": "puppet7"
+    "name": "Puppet 8 - Debian 12",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet8",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet8}"
     }
   },
   {
-    "setfile": {
-      "name": "Debian 11",
-      "value": "debian11-64"
-    },
-    "puppet": {
-      "name": "Puppet 6",
-      "value": 6,
-      "collection": "puppet6"
+    "name": "Puppet 7 - Debian 12",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7}"
     }
   }
 ]
 ```
 
-It is also possible to specify the path to metadata.json and customize the setfiles. For example, to ensure the setfiles use FQDNs and apply the [systemd PIDFile workaround under docker](https://github.com/docker/for-linux/issues/835). This either means either using an older image (CentOS 7, Ubuntu 16.04) or skipping (CentOS 8).
+It is possible to specify the path to metadata.json and customize the setfiles. For example, to ensure the setfiles use FQDNs and apply the [systemd PIDFile workaround under docker](https://github.com/docker/for-linux/issues/835). This either means either using an older image (CentOS 7, Ubuntu 16.04) or skipping (CentOS 8).
 
 ```console
 $ metadata2gha --use-fqdn --pidfile-workaround true /path/to/metadata.json
@@ -89,21 +81,104 @@ This results in the following JSON data
 ```json
 [
   {
-    "name": "CentOS 7",
-    "value": "centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}"
+    "name": "Puppet 7 - CentOS 7",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "centos7-64{hostname=centos7-64-puppet7.example.com,image=centos:7.6.1810}"
+    }
   },
   {
-    "name": "Debian 10",
-    "value": "debian10-64{hostname=debian10-64.example.com}"
+    "name": "Puppet 7 - Debian 12",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7.example.com}"
+    }
   },
   {
-    "name": "Ubuntu 18.04",
-    "value": "ubuntu1804-64{hostname=ubuntu1804-64.example.com}"
+    "name": "Puppet 7 - Ubuntu 22.04",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "ubuntu2204-64{hostname=ubuntu2204-64-puppet7.example.com}"
+    }
   }
 ]
 ```
 
-It is also possible to specify a comma separated list of operating systems as used in `metadata.json` (`CentOS,Ubuntu`).
+If you need multiple hosts in your integration tests this could be achived by using the --beaker_nodes_and_roles option
+
+Option argument is '#HOST:ROLE,ROLE,...;#HOST:..;..' where
+- hosts are separated by ';'
+- host number and roles are separated by ':'
+- Roles are separated by ','
+If you don't need any extra roles use '1;2;..'
+
+The 'master' and 'agent' roles will be automatically added to the first host.
+The 'agent' role will be automatically added to the rest.
+
+```console
+$ metadata2gha --beaker_nodes_and_roles '1:role1,other1;2:role2,other2'
+```
+
+This results in the following JSON data
+```json
+[
+  {
+    "name": "Puppet 7 - Debian 12",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64role1,other1.ma{hostname=debian12-64-puppet7-1}-debian12-64role2,other2.a{hostname=debian12-64-puppet7-2}"
+    }
+  }
+]
+```
+
+If you need to Expand the matrix ie by product versions it could be achived by using the --beaker-facter option
+
+Option argument is 'FACT:LABEL:VALUE,VALUE,..' where
+- Fact, label and values are separated by ':'
+- Values are separated by ','
+
+```console
+$ metadata2gha --beaker-facter 'mongodb_repo_version:MongoDB:4.4,5.0,6.0,7.0'
+```
+
+This results in the following JSON data
+```json
+[
+  {
+    "name": "Puppet 7 - Debian 12 - MongoDB 4.4",
+    "env": {
+        "BEAKER_PUPPET_COLLECTION": "puppet7",
+        "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7}",
+        "BEAKER_FACTER_mongodb_repo_version": "4.4"
+    }
+  },
+  {
+    "name": "Puppet 7 - Debian 12 - MongoDB 5.0",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7}",
+      "BEAKER_FACTER_mongodb_repo_version": "5.0"
+    }
+  },
+  {
+    "name": "Puppet 7 - Debian 12 - MongoDB 6.0",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7}",
+      "BEAKER_FACTER_mongodb_repo_version": "6.0"
+    }
+  },
+  {
+    "name": "Puppet 7 - Debian 12 - MongoDB 7.0",
+    "env": {
+      "BEAKER_PUPPET_COLLECTION": "puppet7",
+      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7}",
+      "BEAKER_FACTER_mongodb_repo_version": "7.0"
+    }
+  }
+]
+```
 
 ## Work with the API
 

--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -11,6 +11,7 @@ options = {
   domain: nil,
   minimum_major_puppet_version: nil,
   beaker_fact: nil,
+  beaker_hosts: nil,
 }
 
 OptionParser.new do |opts|
@@ -40,16 +41,12 @@ OptionParser.new do |opts|
       options[:beaker_facter] = [fact, label, values.split(',')]
     end
   end
-  opts.on('--beaker_nodes_and_roles #NODE:ROLES;#NODE:ROLES;...', 'Expand the setfile string to create multiple nodes with custom roles. Separate roles using commas') do |opt|
-    options[:beaker_nodes_and_roles] = {}
+  opts.on('--beaker-hosts HOSTNAME:ROLES;HOSTNAME:ROLES;...', 'Expand the setfile string to create multiple hosts with custom roles. Roles string; see beaker-hostgenerator') do |opt|
+    options[:beaker_hosts] = {}
     if opt != 'false'
-      opt.split(';').each do |node|
-        node_num, roles = node.split(':', 2)
-        options[:beaker_nodes_and_roles][node_num] = if roles
-                                                       roles.split(',')
-                                                     else
-                                                       []
-                                                     end
+      opt.split(';').each do |host|
+        hostname, roles = host.split(':', 2)
+        options[:beaker_hosts][hostname] = roles
       end
     end
   end

--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -40,6 +40,19 @@ OptionParser.new do |opts|
       options[:beaker_facter] = [fact, label, values.split(',')]
     end
   end
+  opts.on('--beaker_nodes_and_roles #NODE:ROLES;#NODE:ROLES;...', 'Expand the setfile string to create multiple nodes with custom roles. Separate roles using commas') do |opt|
+    options[:beaker_nodes_and_roles] = {}
+    if opt != 'false'
+      opt.split(';').each do |node|
+        node_num, roles = node.split(':', 2)
+        options[:beaker_nodes_and_roles][node_num] = if roles
+                                                       roles.split(',')
+                                                     else
+                                                       []
+                                                     end
+      end
+    end
+  end
 end.parse!
 
 filename = ARGV[0]

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -144,6 +144,7 @@ module PuppetMetadata
         pidfile_workaround: options[:beaker_pidfile_workaround],
         domain: options[:domain],
         puppet_version: puppet_collection,
+        nodes_and_roles: options[:beaker_nodes_and_roles],
       )
     end
   end

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -144,7 +144,7 @@ module PuppetMetadata
         pidfile_workaround: options[:beaker_pidfile_workaround],
         domain: options[:domain],
         puppet_version: puppet_collection,
-        nodes_and_roles: options[:beaker_nodes_and_roles],
+        hosts: options[:beaker_hosts],
       )
     end
   end

--- a/spec/beaker_spec.rb
+++ b/spec/beaker_spec.rb
@@ -21,7 +21,7 @@ describe PuppetMetadata::Beaker do
 
     it { expect(described_class.os_release_to_setfile('SLES', '11')).to be_nil }
 
-    describe 'pidfile_workaround' do
+    context 'with pidfile_workaround' do
       describe 'true' do
         [
           ['CentOS', '6', ['centos6-64', 'CentOS 6']],
@@ -58,14 +58,13 @@ describe PuppetMetadata::Beaker do
       end
     end
 
-    describe 'domain' do
+    context 'with domain' do
       it {
-        expect(described_class.os_release_to_setfile('CentOS', '7', domain: 'mydomain.org',
-                                                                    use_fqdn: true)).to eq(['centos7-64{hostname=centos7-64.mydomain.org}', 'CentOS 7'])
+        expect(described_class.os_release_to_setfile('CentOS', '7', domain: 'mydomain.org')).to eq(['centos7-64{hostname=centos7-64.mydomain.org}', 'CentOS 7'])
       }
     end
 
-    describe 'puppet_version' do
+    context 'with puppet_version' do
       [
         ['CentOS', '7', 'none', ['centos7-64', 'CentOS 7']],
         ['CentOS', '7', 'puppet7', ['centos7-64{hostname=centos7-64-puppet7}', 'CentOS 7']],
@@ -74,22 +73,41 @@ describe PuppetMetadata::Beaker do
       end
     end
 
-    describe 'nodes_and_roles' do
+    context 'with hosts and no roles' do
       [
-        ['CentOS', '7', { '1' => ['role1', 'role2'] }, ['centos7-64role1,role2.ma', 'CentOS 7']],
-        ['CentOS', '7', { '1' => [], '2' => [] }, ['centos7-64.ma{hostname=centos7-64-1}-centos7-64.a{hostname=centos7-64-2}', 'CentOS 7']],
-        ['CentOS', '7', { '1' => ['role1'], '2' => ['role2'] }, ['centos7-64role1.ma{hostname=centos7-64-1}-centos7-64role2.a{hostname=centos7-64-2}', 'CentOS 7']],
-      ].each do |os, release, nodes, expected|
-        it { expect(described_class.os_release_to_setfile(os, release, nodes_and_roles: nodes)).to eq(expected) }
+        ['Debian', '12', { 'foo' => nil }, ['debian12-64{hostname=foo}', 'Debian 12']],
+        ['Debian', '12', { 'foo' => nil, 'bar' => nil }, ['debian12-64.ma{hostname=foo}-debian12-64.a{hostname=bar}', 'Debian 12']],
+      ].each do |os, release, hosts, expected|
+        it { expect(described_class.os_release_to_setfile(os, release, hosts: hosts)).to eq(expected) }
       end
     end
 
-    describe 'domain, puppet_version and nodes_and_roles' do
+    context 'with hosts and roles' do
       [
-        ['CentOS', '7', 'mydomain.org', 'puppet7', { '1' => ['role1'], '2' => ['role2'] },
-         ['centos7-64role1.ma{hostname=centos7-64-puppet7-1.mydomain.org}-centos7-64role2.a{hostname=centos7-64-puppet7-2.mydomain.org}', 'CentOS 7'],],
-      ].each do |os, release, domain, puppet_version, nodes, expected|
-        it { expect(described_class.os_release_to_setfile(os, release, domain: domain, puppet_version: puppet_version, nodes_and_roles: nodes)).to eq(expected) }
+        ['Debian', '12', { 'foo' => 'myrole.ma' }, ['debian12-64myrole.ma{hostname=foo}', 'Debian 12']],
+        ['Debian', '12', { 'foo' => 'myrole,primary.ma' }, ['debian12-64myrole,primary.ma{hostname=foo}', 'Debian 12']],
+        ['Debian', '12', { 'foo' => 'myrole,primary.ma', 'bar' => 'myrole,secondary.a' },
+         ['debian12-64myrole,primary.ma{hostname=foo}-debian12-64myrole,secondary.a{hostname=bar}', 'Debian 12'],],
+      ].each do |os, release, hosts, expected|
+        it { expect(described_class.os_release_to_setfile(os, release, hosts: hosts)).to eq(expected) }
+      end
+    end
+
+    context 'with hosts, roles and domain' do
+      [
+        ['Debian', '12', 'mydomain.org', { 'foo' => 'myrole,primary.ma', 'bar' => 'myrole,secondary.a' },
+         ['debian12-64myrole,primary.ma{hostname=foo.mydomain.org}-debian12-64myrole,secondary.a{hostname=bar.mydomain.org}', 'Debian 12'],],
+      ].each do |os, release, domain, hosts, expected|
+        it { expect(described_class.os_release_to_setfile(os, release, domain: domain, hosts: hosts)).to eq(expected) }
+      end
+    end
+
+    context 'with hosts, roles, domain and puppet_version' do
+      [
+        ['Debian', '12', 'mydomain.org', 'puppet7', { 'foo' => 'myrole,primary.ma', 'bar' => 'myrole,secondary.a' },
+         ['debian12-64myrole,primary.ma{hostname=foo-puppet7.mydomain.org}-debian12-64myrole,secondary.a{hostname=bar-puppet7.mydomain.org}', 'Debian 12'],],
+      ].each do |os, release, domain, puppet_version, hosts, expected|
+        it { expect(described_class.os_release_to_setfile(os, release, domain: domain, puppet_version: puppet_version, hosts: hosts)).to eq(expected) }
       end
     end
   end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -161,32 +161,32 @@ describe PuppetMetadata::GithubActions do
         end
       end
 
-      context 'with option beaker_nodes_and_roles set to one node with custom roles' do
-        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => ['role1', 'role2'] }) }
+      context 'with option beaker_hosts set to one node with custom roles' do
+        let(:options) { super().merge(beaker_hosts: { 'foo' => 'myrole,primary.ma' }) }
 
-        it 'is expected to contain supported os / puppet version / setfile with roles' do
+        it 'is expected to contain supported os / puppet version / custom hostname / custom roles' do
           expect(subject).to include(
-            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64role1,role2.ma' } },
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64myrole,primary.ma{hostname=foo}' } },
           )
         end
       end
 
-      context 'with option beaker_nodes_and_roles set to two node without custom roles' do
-        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => [], '2' => [] }) }
+      context 'with option beaker_hosts set to two node without custom roles' do
+        let(:options) { super().merge(beaker_hosts: { 'foo' => nil, 'bar' => nil }) }
 
-        it 'is expected to contain supported os / puppet version / setfile with nodes' do
+        it 'is expected to contain supported os / puppet version / custom hostnames / required roles for multihost' do
           expect(subject).to include(
-            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64.ma{hostname=archlinuxrolling-64-1}-archlinuxrolling-64.a{hostname=archlinuxrolling-64-2}' } },
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64.ma{hostname=foo}-archlinuxrolling-64.a{hostname=bar}' } },
           )
         end
       end
 
-      context 'with option beaker_nodes_and_roles set to two node with custom roles' do
-        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => ['role1'], '2' => ['role2'] }) }
+      context 'with option beaker_hosts set to two node with custom roles' do
+        let(:options) { super().merge(beaker_hosts: { 'foo' => 'primary.ma', 'bar' => 'secondary.a' }) }
 
-        it 'is expected to contain supported os / puppet version / setfile with nodes and roles' do
+        it 'is expected to contain supported os / puppet version / custom hostnames / custom roles' do
           expect(subject).to include(
-            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64role1.ma{hostname=archlinuxrolling-64-1}-archlinuxrolling-64role2.a{hostname=archlinuxrolling-64-2}' } },
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64primary.ma{hostname=foo}-archlinuxrolling-64secondary.a{hostname=bar}' } },
           )
         end
       end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -123,28 +123,28 @@ describe PuppetMetadata::GithubActions do
       it 'is expected to contain supported os / puppet version combinations' do
         expect(subject).to contain_exactly(
           { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64' } },
-          { name: 'Puppet 5 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos7-64' } },
-          { name: 'Puppet 6 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos7-64' } },
-          { name: 'Puppet 7 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos7-64' } },
-          { name: 'Puppet 8 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos7-64' } },
-          { name: 'Puppet 5 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos8-64' } },
-          { name: 'Puppet 6 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos8-64' } },
-          { name: 'Puppet 7 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos8-64' } },
-          { name: 'Puppet 8 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos8-64' } },
-          { name: 'Puppet 6 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos9-64' } },
-          { name: 'Puppet 7 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos9-64' } },
-          { name: 'Puppet 8 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos9-64' } },
-          { name: 'Puppet 5 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian9-64' } },
-          { name: 'Puppet 6 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian9-64' } },
-          { name: 'Puppet 7 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian9-64' } },
-          { name: 'Puppet 5 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian10-64' } },
-          { name: 'Puppet 6 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian10-64' } },
-          { name: 'Puppet 7 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian10-64' } },
-          { name: 'Puppet 8 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian10-64' } },
-          { name: 'Puppet 7 - Debian 12', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian12-64' } },
-          { name: 'Puppet 8 - Debian 12', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian12-64' } },
-          { name: 'Puppet 7 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'fedora36-64' } },
-          { name: 'Puppet 8 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'fedora36-64' } },
+          { name: 'Puppet 5 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos7-64{hostname=centos7-64-puppet5}' } },
+          { name: 'Puppet 6 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos7-64{hostname=centos7-64-puppet6}' } },
+          { name: 'Puppet 7 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos7-64{hostname=centos7-64-puppet7}' } },
+          { name: 'Puppet 8 - CentOS 7', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos7-64{hostname=centos7-64-puppet8}' } },
+          { name: 'Puppet 5 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'centos8-64{hostname=centos8-64-puppet5}' } },
+          { name: 'Puppet 6 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos8-64{hostname=centos8-64-puppet6}' } },
+          { name: 'Puppet 7 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos8-64{hostname=centos8-64-puppet7}' } },
+          { name: 'Puppet 8 - CentOS 8', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos8-64{hostname=centos8-64-puppet8}' } },
+          { name: 'Puppet 6 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'centos9-64{hostname=centos9-64-puppet6}' } },
+          { name: 'Puppet 7 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'centos9-64{hostname=centos9-64-puppet7}' } },
+          { name: 'Puppet 8 - CentOS 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'centos9-64{hostname=centos9-64-puppet8}' } },
+          { name: 'Puppet 5 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian9-64{hostname=debian9-64-puppet5}' } },
+          { name: 'Puppet 6 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian9-64{hostname=debian9-64-puppet6}' } },
+          { name: 'Puppet 7 - Debian 9', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian9-64{hostname=debian9-64-puppet7}' } },
+          { name: 'Puppet 5 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet5', 'BEAKER_SETFILE' => 'debian10-64{hostname=debian10-64-puppet5}' } },
+          { name: 'Puppet 6 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet6', 'BEAKER_SETFILE' => 'debian10-64{hostname=debian10-64-puppet6}' } },
+          { name: 'Puppet 7 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian10-64{hostname=debian10-64-puppet7}' } },
+          { name: 'Puppet 8 - Debian 10', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian10-64{hostname=debian10-64-puppet8}' } },
+          { name: 'Puppet 7 - Debian 12', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'debian12-64{hostname=debian12-64-puppet7}' } },
+          { name: 'Puppet 8 - Debian 12', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'debian12-64{hostname=debian12-64-puppet8}' } },
+          { name: 'Puppet 7 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet7', 'BEAKER_SETFILE' => 'fedora36-64{hostname=fedora36-64-puppet7}' } },
+          { name: 'Puppet 8 - Fedora 36', env: { 'BEAKER_PUPPET_COLLECTION' => 'puppet8', 'BEAKER_SETFILE' => 'fedora36-64{hostname=fedora36-64-puppet8}' } },
           { name: 'Distro Puppet - Fedora 38', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'fedora38-64' } },
           { name: 'Distro Puppet - Fedora 40', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'fedora40-64' } },
         )
@@ -160,6 +160,36 @@ describe PuppetMetadata::GithubActions do
           )
         end
       end
+
+      context 'with option beaker_nodes_and_roles set to one node with custom roles' do
+        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => ['role1', 'role2'] }) }
+
+        it 'is expected to contain supported os / puppet version / setfile with roles' do
+          expect(subject).to include(
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64role1,role2.ma' } },
+          )
+        end
+      end
+
+      context 'with option beaker_nodes_and_roles set to two node without custom roles' do
+        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => [], '2' => [] }) }
+
+        it 'is expected to contain supported os / puppet version / setfile with nodes' do
+          expect(subject).to include(
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64.ma{hostname=archlinuxrolling-64-1}-archlinuxrolling-64.a{hostname=archlinuxrolling-64-2}' } },
+          )
+        end
+      end
+
+      context 'with option beaker_nodes_and_roles set to two node with custom roles' do
+        let(:options) { super().merge(beaker_nodes_and_roles: { '1' => ['role1'], '2' => ['role2'] }) }
+
+        it 'is expected to contain supported os / puppet version / setfile with nodes and roles' do
+          expect(subject).to include(
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64role1.ma{hostname=archlinuxrolling-64-1}-archlinuxrolling-64role2.a{hostname=archlinuxrolling-64-2}' } },
+          )
+        end
+      end
     end
 
     describe 'github_action_test_matrix' do
@@ -170,28 +200,28 @@ describe PuppetMetadata::GithubActions do
       it 'is expected to contain supported os / puppet version combinations' do
         expect(subject).to contain_exactly(
           { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-          { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
+          { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+          { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+          { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+          { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
           { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
           { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
         )
@@ -203,24 +233,24 @@ describe PuppetMetadata::GithubActions do
         it 'is expected to contain supported os / puppet version combinations excluding puppet 5' do
           expect(subject).to contain_exactly(
             { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
             { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
             { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
@@ -233,24 +263,24 @@ describe PuppetMetadata::GithubActions do
         it 'is expected to contain supported os / puppet version combinations with image option' do
           expect(subject).to contain_exactly(
             { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{image=centos:7.6.1810}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
+            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
+            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
+            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
+            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
+            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
+            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
+            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
             { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
             { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
@@ -262,7 +292,7 @@ describe PuppetMetadata::GithubActions do
 
         it 'is expected to contain supported os / puppet version combinations with hostname option' do
           expect(subject).to contain_exactly(
-            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64{hostname=archlinuxrolling-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
+            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64{hostname=archlinuxrolling-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
             { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
             { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
             { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
@@ -285,8 +315,8 @@ describe PuppetMetadata::GithubActions do
             { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
             { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7.example.com}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
             { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8.example.com}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64{hostname=fedora38-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
-            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64{hostname=fedora40-64-none.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
+            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64{hostname=fedora38-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
+            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64{hostname=fedora40-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
           )
         end
       end


### PR DESCRIPTION
We have a few modules that override the modulesync generated ci.yml because they have integration tests that require multiple hosts with custom roles.
This PR add a new option to `metadata2gha` that can be used to generate setfile strings to bring up multiple hosts in gha.