### PR TITLE
Drop deprecated use_fqdn option and github_action_test_matrix output

### DIFF
--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -6,7 +6,6 @@ require 'puppet_metadata'
 PidfileWorkaround = Object.new
 
 options = {
-  beaker_use_fqdn: false,
   beaker_pidfile_workaround: false,
   domain: nil,
   minimum_major_puppet_version: nil,
@@ -28,7 +27,6 @@ OptionParser.new do |opts|
 
   opts.banner = "Usage: #{$0} [options] metadata"
 
-  opts.on('--[no-]use-fqdn', 'Generate beaker setfiles with a FQDN') { |opt| options[:beaker_use_fqdn] = opt }
   opts.on('--pidfile-workaround VALUE', 'Generate the systemd PIDFile workaround to work around a docker bug', PidfileWorkaround) { |opt| options[:beaker_pidfile_workaround] = opt }
   opts.on('-d', '--domain VALUE', 'the domain for the box, only used when --use-fqdn is set to true') { |opt| options[:domain] = opt }
   opts.on('--minimum-major-puppet-version VERSION', "Don't create actions for Puppet versions less than this major version") { |opt| options[:minimum_major_puppet_version] = opt }

--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -42,8 +42,6 @@ module PuppetMetadata
       #   The Operating System string as metadata.json knows it, which in turn is
       #   based on Facter's operatingsystem fact.
       # @param [String] release The OS release
-      # @param [Boolean] use_fqdn
-      #   Whether or not to use a FQDN, ensuring a domain (deprecated, use domain)
       # @param [Boolean, Array[String]] pidfile_workaround
       #   Whether or not to apply the systemd PIDFile workaround. This is only
       #   needed when the daemon uses PIDFile in its service file and using
@@ -63,13 +61,12 @@ module PuppetMetadata
       #
       # @return [nil] If no setfile is available
       # @return [Array<(String, String)>] The beaker setfile description with a readable name
-      def os_release_to_setfile(os, release, use_fqdn: false, pidfile_workaround: false, domain: nil, puppet_version: nil, hosts: nil)
+      def os_release_to_setfile(os, release, pidfile_workaround: false, domain: nil, puppet_version: nil, hosts: nil)
         return unless os_supported?(os)
 
         aos = adjusted_os(os)
         name = "#{aos}#{release.tr('.', '')}-64"
         human_name = "#{os} #{release}"
-        domain ||= 'example.com' if use_fqdn
 
         hosts_settings = []
         if hosts

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -15,8 +15,6 @@ module PuppetMetadata
         puppet_major_versions: puppet_major_versions,
         puppet_unit_test_matrix: puppet_unit_test_matrix,
         puppet_beaker_test_matrix: puppet_beaker_test_matrix,
-        # Deprecated
-        github_action_test_matrix: github_action_test_matrix,
       }
     end
 
@@ -103,28 +101,6 @@ module PuppetMetadata
             env: env,
           }
         end
-      end
-
-      matrix_include
-    end
-
-    def github_action_test_matrix
-      matrix_include = []
-
-      beaker_os_releases do |os, release, puppet_version|
-        next if puppet_version_below_minimum?(puppet_version[:value])
-
-        setfile = os_release_to_beaker_setfile(os, release, puppet_version[:collection])
-        next unless setfile
-
-        matrix_include << {
-          name: "#{puppet_version[:name]} - #{setfile[1]}",
-          setfile: {
-            name: setfile[1],
-            value: setfile[0],
-          },
-          puppet: puppet_version,
-        }
       end
 
       matrix_include

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -140,7 +140,6 @@ module PuppetMetadata
       PuppetMetadata::Beaker.os_release_to_setfile(
         os,
         release,
-        use_fqdn: options[:beaker_use_fqdn],
         pidfile_workaround: options[:beaker_pidfile_workaround],
         domain: options[:domain],
         puppet_version: puppet_collection,

--- a/spec/beaker_spec.rb
+++ b/spec/beaker_spec.rb
@@ -34,10 +34,10 @@ describe PuppetMetadata::Beaker do
           it { expect(described_class.os_release_to_setfile(os, release, pidfile_workaround: true)).to eq(expected) }
         end
 
-        describe 'use_fqdn' do
+        describe 'domain' do
           it {
             expect(described_class.os_release_to_setfile('CentOS', '7', pidfile_workaround: true,
-                                                                        use_fqdn: true)).to eq(['centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}', 'CentOS 7'])
+                                                                        domain: 'example.com')).to eq(['centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}', 'CentOS 7'])
           }
         end
       end

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -4,11 +4,9 @@ describe PuppetMetadata::GithubActions do
   subject { described_class.new(PuppetMetadata::Metadata.new(JSON.parse(JSON.dump(metadata))), options) }
 
   let(:beaker_pidfile_workaround) { false }
-  let(:beaker_use_fqdn) { false }
   let(:minimum_major_puppet_version) { nil }
   let(:options) do
     {
-      beaker_use_fqdn: beaker_use_fqdn,
       beaker_pidfile_workaround: beaker_pidfile_workaround,
       minimum_major_puppet_version: minimum_major_puppet_version,
     }
@@ -53,7 +51,6 @@ describe PuppetMetadata::GithubActions do
     subject { super().outputs }
 
     let(:beaker_pidfile_workaround) { false }
-    let(:beaker_use_fqdn) { false }
 
     it { is_expected.to be_an_instance_of(Hash) }
     it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :puppet_beaker_test_matrix, :github_action_test_matrix) }
@@ -287,8 +284,8 @@ describe PuppetMetadata::GithubActions do
         end
       end
 
-      context 'when beaker_use_fqdn is true' do
-        let(:beaker_use_fqdn) { true }
+      context 'when domain is set' do
+        let(:options) { super().merge(domain: 'example.com') }
 
         it 'is expected to contain supported os / puppet version combinations with hostname option' do
           expect(subject).to contain_exactly(

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -53,7 +53,7 @@ describe PuppetMetadata::GithubActions do
     let(:beaker_pidfile_workaround) { false }
 
     it { is_expected.to be_an_instance_of(Hash) }
-    it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :puppet_beaker_test_matrix, :github_action_test_matrix) }
+    it { expect(subject.keys).to contain_exactly(:puppet_major_versions, :puppet_unit_test_matrix, :puppet_beaker_test_matrix) }
 
     describe 'puppet_major_versions' do
       subject { super()[:puppet_major_versions] }
@@ -187,133 +187,13 @@ describe PuppetMetadata::GithubActions do
           )
         end
       end
-    end
-
-    describe 'github_action_test_matrix' do
-      subject { super()[:github_action_test_matrix] }
-
-      it { is_expected.to be_an_instance_of(Array) }
-
-      it 'is expected to contain supported os / puppet version combinations' do
-        expect(subject).to contain_exactly(
-          { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-          { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5}' }, puppet: { collection: 'puppet5', name: 'Puppet 5', value: 5 } },
-          { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-          { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-          { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-          { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
-          { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
-        )
-      end
-
-      context 'when minimum_major_puppet_version is set to 6' do
-        let(:minimum_major_puppet_version) { '6' }
-
-        it 'is expected to contain supported os / puppet version combinations excluding puppet 5' do
-          expect(subject).to contain_exactly(
-            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
-            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
-          )
-        end
-      end
-
-      context 'when beaker_pidfile_workaround is true' do
-        let(:beaker_pidfile_workaround) { true }
-
-        it 'is expected to contain supported os / puppet version combinations with image option' do
-          expect(subject).to contain_exactly(
-            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5,image=centos:7.6.1810}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6}' }, puppet: { collection: 'puppet6', name: 'Puppet 6', value: 6 } },
-            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
-            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
-          )
-        end
-      end
 
       context 'when domain is set' do
         let(:options) { super().merge(domain: 'example.com') }
 
         it 'is expected to contain supported os / puppet version combinations with hostname option' do
-          expect(subject).to contain_exactly(
-            { name: 'Distro Puppet - Archlinux rolling', setfile: { name: 'Archlinux rolling', value: 'archlinuxrolling-64{hostname=archlinuxrolling-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: nil } },
-            { name: 'Puppet 8 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - CentOS 7', setfile: { name: 'CentOS 7', value: 'centos7-64{hostname=centos7-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 8 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - CentOS 8', setfile: { name: 'CentOS 8', value: 'centos8-64{hostname=centos8-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 8 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - CentOS 9', setfile: { name: 'CentOS 9', value: 'centos9-64{hostname=centos9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 7 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 9', setfile: { name: 'Debian 9', value: 'debian9-64{hostname=debian9-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 8 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 6 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet6.example.com}' }, puppet: { name: 'Puppet 6', value: 6, collection: 'puppet6' } },
-            { name: 'Puppet 5 - Debian 10', setfile: { name: 'Debian 10', value: 'debian10-64{hostname=debian10-64-puppet5.example.com}' }, puppet: { name: 'Puppet 5', value: 5, collection: 'puppet5' } },
-            { name: 'Puppet 7 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet7.example.com}' }, puppet: { name: 'Puppet 7', value: 7, collection: 'puppet7' } },
-            { name: 'Puppet 8 - Debian 12', setfile: { name: 'Debian 12', value: 'debian12-64{hostname=debian12-64-puppet8.example.com}' }, puppet: { name: 'Puppet 8', value: 8, collection: 'puppet8' } },
-            { name: 'Puppet 7 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet7.example.com}' }, puppet: { collection: 'puppet7', name: 'Puppet 7', value: 7 } },
-            { name: 'Puppet 8 - Fedora 36', setfile: { name: 'Fedora 36', value: 'fedora36-64{hostname=fedora36-64-puppet8.example.com}' }, puppet: { collection: 'puppet8', name: 'Puppet 8', value: 8 } },
-            { name: 'Distro Puppet - Fedora 38', setfile: { name: 'Fedora 38', value: 'fedora38-64{hostname=fedora38-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 7 } },
-            { name: 'Distro Puppet - Fedora 40', setfile: { name: 'Fedora 40', value: 'fedora40-64{hostname=fedora40-64.example.com}' }, puppet: { collection: 'none', name: 'Distro Puppet', value: 8 } },
+          expect(subject).to include(
+            { name: 'Distro Puppet - Archlinux rolling', env: { 'BEAKER_PUPPET_COLLECTION' => 'none', 'BEAKER_SETFILE' => 'archlinuxrolling-64{hostname=archlinuxrolling-64.example.com}' } },
           )
         end
       end


### PR DESCRIPTION
Were superseded by respectively `domain` and `puppet_beaker_test_matrix`.