### PR TITLE
Debian 12: Cleanup legacy non-AIO code

### DIFF
--- a/lib/puppet_metadata/operatingsystem.rb
+++ b/lib/puppet_metadata/operatingsystem.rb
@@ -220,11 +220,6 @@ module PuppetMetadata
       # @return [Optional[Integer]] The Puppet major version, if any
       def os_release_puppet_version(operatingsystem, release)
         case operatingsystem
-        when 'Debian'
-          case release
-          when '12'
-            7
-          end
         when 'Fedora'
           case release
           when '39', '40'


### PR DESCRIPTION
In the epast we had this code snippet to determine the puppet agent version in debian.org for Debian 12. But we don't use that code branch anymore because Puppet now offers Puppet 7/8 packages that we prefer.