### PR TITLE
Add script to display supported setfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ The metadata object has several different methods that we can call
 [7] pry(main)>
 ```
 
+## List supported setfiles
+
+When running beaker on the CLI, you can specify a specific setfile. `puppet_metadata` provides `bin/setfiles` to list all setfiles:
+
+```
+$ bundle exec setfiles
+Skipping EOL operating system Debian 10
+Skipping EOL operating system Ubuntu 18.04
+BEAKER_SETFILE="centos9-64{hostname=centos9-64-puppet8.example.com}"
+BEAKER_SETFILE="centos9-64{hostname=centos9-64-puppet7.example.com}"
+BEAKER_SETFILE="debian11-64{hostname=debian11-64-puppet8.example.com}"
+BEAKER_SETFILE="debian11-64{hostname=debian11-64-puppet7.example.com}"
+BEAKER_SETFILE="ubuntu2004-64{hostname=ubuntu2004-64-puppet8.example.com}"
+BEAKER_SETFILE="ubuntu2004-64{hostname=ubuntu2004-64-puppet7.example.com}"
+```
+
+As an argument you can provide a path to a metadata.json. If none provided, it assumes that there's a metadata.json in the same directory where you run the command.
+To make copy and paste easier, each setfile string is prefixed so it can directly be used as environment variable.
+
 ## Transfer Notice
 
 This plugin was originally authored by [Ewoud Kohl van Wijngaarden](https://github.com/ekohl).

--- a/bin/setfiles
+++ b/bin/setfiles
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require 'json'
+require 'puppet_metadata'
+
+filename = ARGV[0]
+filename = 'metadata.json' if filename.nil? || filename.empty?
+
+begin
+  metadata = PuppetMetadata.read(filename)
+rescue StandardError => e
+  warn "Failed to read #{filename}: #{e}"
+  exit 2
+end
+
+options = {
+  beaker_pidfile_workaround: false,
+  domain: 'example.com',
+  minimum_major_puppet_version: nil,
+  beaker_fact: nil,
+  beaker_hosts: nil,
+}
+
+metadata.github_actions(options).outputs[:puppet_beaker_test_matrix].each do |os|
+  puts "BEAKER_SETFILE=\"#{os[:env]['BEAKER_SETFILE']}\""
+end

--- a/puppet_metadata.gemspec
+++ b/puppet_metadata.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.7', '< 4')
 
-  s.executables << 'metadata2gha'
+  s.executables = ['metadata2gha', 'setfiles']
   s.files = Dir['lib/**/*.rb']
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options << '--main' << 'README.md'

--- a/spec/operatingsystem_spec.rb
+++ b/spec/operatingsystem_spec.rb
@@ -21,8 +21,8 @@ describe PuppetMetadata::OperatingSystem do
     context 'with CentOS' do
       let(:os) { 'CentOS' }
 
-      it 'returns 7 and 9' do
-        expect(described_class.supported_releases(os)).to match_array(%w[7 9])
+      it 'returns 9' do
+        expect(described_class.supported_releases(os)).to match_array(%w[9])
       end
 
       it 'the last entry matches latest_release' do


### PR DESCRIPTION
This is a simple implementation to parse a metadata.json and output all supported beaker setfiles. The output will contain our default hostname/domain:

```console
$ bundle exec setfiles
Skipping EOL operating system Debian 10
Skipping EOL operating system Ubuntu 18.04
BEAKER_SETFILE="centos9-64{hostname=centos9-64-puppet8.example.com}"
BEAKER_SETFILE="centos9-64{hostname=centos9-64-puppet7.example.com}"
BEAKER_SETFILE="debian11-64{hostname=debian11-64-puppet8.example.com}"
BEAKER_SETFILE="debian11-64{hostname=debian11-64-puppet7.example.com}"
BEAKER_SETFILE="ubuntu2004-64{hostname=ubuntu2004-64-puppet8.example.com}"
BEAKER_SETFILE="ubuntu2004-64{hostname=ubuntu2004-64-puppet7.example.com}"
```