### PR TITLE
Add Debian 11 EoL Date: 2024-08-14

### DIFF
--- a/lib/puppet_metadata/operatingsystem.rb
+++ b/lib/puppet_metadata/operatingsystem.rb
@@ -32,7 +32,7 @@ module PuppetMetadata
       'Debian' => {
         # TODO: EOL is standard support, not the extended life cycle
         '12' => nil, # '~2026',
-        '11' => nil, # '~2024',
+        '11' => '2024-08-14',
         '10' => '2022-09-10',
         '9' => '2020-07-06',
         '8' => '2018-06-17',

--- a/spec/operatingsystem_spec.rb
+++ b/spec/operatingsystem_spec.rb
@@ -45,8 +45,8 @@ describe PuppetMetadata::OperatingSystem do
     context 'with Debian' do
       let(:os) { 'Debian' }
 
-      it 'returns 11, 12' do
-        expect(described_class.supported_releases(os)).to match_array(%w[11 12])
+      it 'returns 12' do
+        expect(described_class.supported_releases(os)).to contain_exactly('12')
       end
 
       it 'the last entry matches latest_release' do


### PR DESCRIPTION
Based on https://www.debian.org/releases/bullseye/