### PR TITLE
Set latest puppet version from 7->8

### DIFF
--- a/lib/puppet_metadata/metadata.rb
+++ b/lib/puppet_metadata/metadata.rb
@@ -143,9 +143,9 @@ module PuppetMetadata
       requirement = requirements['puppet']
       raise Exception, 'No Puppet requirement found' unless requirement
 
-      # Current latest major is 7. It is highly recommended that modules
+      # Current latest major is 8. It is highly recommended that modules
       # actually specify exact bounds, but this prevents an infinite loop.
-      end_major = (requirement.end == SemanticPuppet::Version::MAX) ? 7 : requirement.end.major
+      end_major = (requirement.end == SemanticPuppet::Version::MAX) ? 8 : requirement.end.major
 
       (requirement.begin.major..end_major).select do |major|
         requirement.include?(SemanticPuppet::Version.new(major, 0,

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -153,7 +153,7 @@ describe PuppetMetadata::Metadata do
                           ])
           end
 
-          it { expect(subject.puppet_major_versions).to eq([5, 6, 7]) }
+          it { expect(subject.puppet_major_versions).to eq([5, 6, 7, 8]) }
         end
       end
 


### PR DESCRIPTION
Ideally we wouldn't hardcode this. But there is currently no easy way to determine the latest version.