### PR TITLE
Remove pidfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,39 +143,6 @@ Beaker test matrix formatted for readability
 ]
 ```
 
-It is possible to specify the path to metadata.json and customize the setfiles. For example, to ensure the setfiles use FQDNs and apply the [systemd PIDFile workaround under docker](https://github.com/docker/for-linux/issues/835). This either means either using an older image (CentOS 7, Ubuntu 16.04) or skipping (CentOS 8).
-
-```console
-$ metadata2gha --use-fqdn --pidfile-workaround true /path/to/metadata.json
-```
-
-This results in the following JSON data
-```json
-[
-  {
-    "name": "Puppet 7 - CentOS 7",
-    "env": {
-      "BEAKER_PUPPET_COLLECTION": "puppet7",
-      "BEAKER_SETFILE": "centos7-64{hostname=centos7-64-puppet7.example.com,image=centos:7.6.1810}"
-    }
-  },
-  {
-    "name": "Puppet 7 - Debian 12",
-    "env": {
-      "BEAKER_PUPPET_COLLECTION": "puppet7",
-      "BEAKER_SETFILE": "debian12-64{hostname=debian12-64-puppet7.example.com}"
-    }
-  },
-  {
-    "name": "Puppet 7 - Ubuntu 22.04",
-    "env": {
-      "BEAKER_PUPPET_COLLECTION": "puppet7",
-      "BEAKER_SETFILE": "ubuntu2204-64{hostname=ubuntu2204-64-puppet7.example.com}"
-    }
-  }
-]
-```
-
 If you need custom hostname or multiple hosts in your integration tests this could be achived by using the --beaker-hosts option
 
 Option argument is 'HOSTNAME:ROLES;HOSTNAME:..;..' where

--- a/bin/metadata2gha
+++ b/bin/metadata2gha
@@ -3,10 +3,7 @@ require 'optparse'
 require 'json'
 require 'puppet_metadata'
 
-PidfileWorkaround = Object.new
-
 options = {
-  beaker_pidfile_workaround: false,
   domain: nil,
   minimum_major_puppet_version: nil,
   beaker_fact: nil,
@@ -14,20 +11,8 @@ options = {
 }
 
 OptionParser.new do |opts|
-  opts.accept(PidfileWorkaround) do |value|
-    case value
-    when 'true'
-      true
-    when 'false'
-      false
-    else
-      value.split(',')
-    end
-  end
-
   opts.banner = "Usage: #{$0} [options] metadata"
 
-  opts.on('--pidfile-workaround VALUE', 'Generate the systemd PIDFile workaround to work around a docker bug', PidfileWorkaround) { |opt| options[:beaker_pidfile_workaround] = opt }
   opts.on('-d', '--domain VALUE', 'the domain for the box, only used when --use-fqdn is set to true') { |opt| options[:domain] = opt }
   opts.on('--minimum-major-puppet-version VERSION', "Don't create actions for Puppet versions less than this major version") { |opt| options[:minimum_major_puppet_version] = opt }
   opts.on('--beaker-facter FACT:LABEL:VALUES', 'Expand the matrix based on a fact. Separate values using commas') do |opt|

--- a/bin/setfiles
+++ b/bin/setfiles
@@ -16,7 +16,6 @@ rescue StandardError => e
 end
 
 options = {
-  beaker_pidfile_workaround: false,
   domain: 'example.com',
   minimum_major_puppet_version: nil,
   beaker_fact: nil,

--- a/lib/puppet_metadata/beaker.rb
+++ b/lib/puppet_metadata/beaker.rb
@@ -4,25 +4,6 @@ module PuppetMetadata
   # @see https://rubygems.org/gems/beaker
   # @see https://rubygems.org/gems/beaker-hostgenerator
   class Beaker
-    # These images have an older systemd, which they work with
-    # PIDFile parameter
-    PIDFILE_COMPATIBLE_IMAGES = {
-      'CentOS' => {
-        '7' => 'centos:7.6.1810',
-      },
-      'Ubuntu' => {
-        '16.04' => 'ubuntu:xenial-20191212',
-      },
-    }.freeze
-
-    # There is no CentOS 8 image that works with PIDFile in systemd
-    # unit files
-    PIDFILE_INCOMPATIBLE = {
-      'CentOS' => ['8'],
-      'AlmaLinux' => ['8'],
-      'OracleLinux' => ['7', '8'],
-      'Rocky' => ['8'],
-    }.freeze
     class << self
       # modifies the operating system name to suit beaker-hostgenerator
       # @param [String] os
@@ -42,13 +23,6 @@ module PuppetMetadata
       #   The Operating System string as metadata.json knows it, which in turn is
       #   based on Facter's operatingsystem fact.
       # @param [String] release The OS release
-      # @param [Boolean, Array[String]] pidfile_workaround
-      #   Whether or not to apply the systemd PIDFile workaround. This is only
-      #   needed when the daemon uses PIDFile in its service file and using
-      #   Docker as a Beaker hypervisor. This is to work around Docker's
-      #   limitations.
-      #   When a boolean, it's applied on applicable operating systems. On arrays
-      #   it's applied only when os is included in the provided array.
       # @param [Optional[String]] domain
       #   Enforce a domain to be appended to the hostname, making it an FQDN
       # @param [Optional[String]] puppet_version
@@ -61,7 +35,7 @@ module PuppetMetadata
       #
       # @return [nil] If no setfile is available
       # @return [Array<(String, String)>] The beaker setfile description with a readable name
-      def os_release_to_setfile(os, release, pidfile_workaround: false, domain: nil, puppet_version: nil, hosts: nil)
+      def os_release_to_setfile(os, release, domain: nil, puppet_version: nil, hosts: nil)
         return unless os_supported?(os)
 
         aos = adjusted_os(os)
@@ -96,21 +70,10 @@ module PuppetMetadata
         end
 
         options = {}
-        # Docker messes up cgroups and some systemd versions can't deal with
-        # that when PIDFile is used.
-        image_to_use = nil
-        if pidfile_workaround?(pidfile_workaround, os)
-          return if PIDFILE_INCOMPATIBLE[os]&.include?(release)
-
-          if (image = PIDFILE_COMPATIBLE_IMAGES.dig(os, release))
-            image_to_use = image
-          end
-        end
 
         setfile_parts = []
         hosts_settings.each do |host_settings|
           options[:hostname] = host_settings['hostname'] unless host_settings['hostname'].empty?
-          options[:image] = image_to_use if image_to_use
           setfile_parts << build_setfile(host_settings['name'], options)
         end
 
@@ -124,10 +87,6 @@ module PuppetMetadata
       end
 
       private
-
-      def pidfile_workaround?(pidfile_workaround, os)
-        pidfile_workaround && (!pidfile_workaround.is_a?(Array) || pidfile_workaround.include?(os))
-      end
 
       def build_setfile(name, options)
         "#{name}#{"{#{options.map { |key, value| "#{key}=#{value}" }.join(',')}}" if options.any?}"

--- a/lib/puppet_metadata/github_actions.rb
+++ b/lib/puppet_metadata/github_actions.rb
@@ -138,7 +138,6 @@ module PuppetMetadata
       PuppetMetadata::Beaker.os_release_to_setfile(
         os,
         release,
-        pidfile_workaround: options[:beaker_pidfile_workaround],
         domain: options[:domain],
         puppet_version: puppet_collection,
         hosts: options[:beaker_hosts],

--- a/spec/beaker_spec.rb
+++ b/spec/beaker_spec.rb
@@ -21,43 +21,6 @@ describe PuppetMetadata::Beaker do
 
     it { expect(described_class.os_release_to_setfile('SLES', '11')).to be_nil }
 
-    context 'with pidfile_workaround' do
-      describe 'true' do
-        [
-          ['CentOS', '6', ['centos6-64', 'CentOS 6']],
-          ['CentOS', '7', ['centos7-64{image=centos:7.6.1810}', 'CentOS 7']],
-          ['CentOS', '8', nil],
-          ['CentOS', '9', ['centos9-64', 'CentOS 9']],
-          ['Ubuntu', '16.04', ['ubuntu1604-64{image=ubuntu:xenial-20191212}', 'Ubuntu 16.04']],
-          ['Ubuntu', '18.04', ['ubuntu1804-64', 'Ubuntu 18.04']],
-        ].each do |os, release, expected|
-          it { expect(described_class.os_release_to_setfile(os, release, pidfile_workaround: true)).to eq(expected) }
-        end
-
-        describe 'domain' do
-          it {
-            expect(described_class.os_release_to_setfile('CentOS', '7', pidfile_workaround: true,
-                                                                        domain: 'example.com')).to eq(['centos7-64{hostname=centos7-64.example.com,image=centos:7.6.1810}', 'CentOS 7'])
-          }
-        end
-      end
-
-      describe 'as an array' do
-        it {
-          expect(described_class.os_release_to_setfile('CentOS', '8',
-                                                       pidfile_workaround: [])).to eq(['centos8-64', 'CentOS 8'])
-        }
-
-        it {
-          expect(described_class.os_release_to_setfile('CentOS', '8',
-                                                       pidfile_workaround: ['Debian'])).to eq(['centos8-64',
-                                                                                               'CentOS 8',])
-        }
-
-        it { expect(described_class.os_release_to_setfile('CentOS', '8', pidfile_workaround: ['CentOS'])).to be_nil }
-      end
-    end
-
     context 'with domain' do
       it {
         expect(described_class.os_release_to_setfile('CentOS', '7', domain: 'mydomain.org')).to eq(['centos7-64{hostname=centos7-64.mydomain.org}', 'CentOS 7'])

--- a/spec/github_actions_spec.rb
+++ b/spec/github_actions_spec.rb
@@ -4,11 +4,9 @@ describe PuppetMetadata::GithubActions do
   subject { described_class.new(PuppetMetadata::Metadata.new(JSON.parse(JSON.dump(metadata))), options) }
 
   let(:at) { Date.new(2020, 1, 1) }
-  let(:beaker_pidfile_workaround) { false }
   let(:minimum_major_puppet_version) { nil }
   let(:options) do
     {
-      beaker_pidfile_workaround: beaker_pidfile_workaround,
       minimum_major_puppet_version: minimum_major_puppet_version,
     }
   end
@@ -54,8 +52,6 @@ describe PuppetMetadata::GithubActions do
   # rubocop:disable Layout/LineLength,RSpec/ExampleLength
   describe 'outputs' do
     subject { super().outputs(at) }
-
-    let(:beaker_pidfile_workaround) { false }
 
     it { is_expected.to be_an_instance_of(Hash) }
     it { expect(subject.keys).to contain_exactly(:puppet_unit_test_matrix, :puppet_beaker_test_matrix) }


### PR DESCRIPTION
Certain older operating systems required workarounds in combination with docker and cgroups. None of those versions are supported anymore by us (mostly CentOS 7 or Ubuntu 16.04, in combination with specific software).

We can now remove this feature.