### PR TITLE
CLI: Use correct option for metadata.json path

### DIFF
--- a/bin/puppet-metadata
+++ b/bin/puppet-metadata
@@ -18,7 +18,7 @@ def main
   global = OptionParser.new do |opts|
     opts.banner = "Usage: #{opts.program_name} [options] <action> [options]"
     opts.on('--filename METADATA', 'Metadata filename') do |value|
-      options[:verbose] = value
+      options[:filename] = value
     end
 
     opts.separator ''


### PR DESCRIPTION
The correct option is `filename`, not `verbose`:

https://github.com/voxpupuli/puppet_metadata/blob/d85ac8b708a06a9c8b0cbc61ced1f81b7dea688c/lib/puppet_metadata/base_command.rb#L12