### PR TITLE
supported_releases: Don't fail on unknown operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ The metadata object has several different methods that we can call
 [7] pry(main)>
 ```
 
+## Get all versions for an Operating System that are not EoL
+
+```
+[1] pry(main)> require 'puppet_metadata'
+=> true
+[2] pry(main)> os = PuppetMetadata::OperatingSystem.supported_releases('RedHat')
+=> ["8", "9", "10"]
+[3] pry(main)> os = PuppetMetadata::OperatingSystem.supported_releases('windows')
+=> []
+[4] pry(main)>
+```
+
+**For Operating systems without any known releases, an empty array is returned.**
+
 ## List supported setfiles
 
 When running beaker on the CLI, you can specify a specific setfile. `puppet_metadata` provides `bin/setfiles` to list all setfiles:

--- a/lib/puppet_metadata/operatingsystem.rb
+++ b/lib/puppet_metadata/operatingsystem.rb
@@ -265,6 +265,11 @@ module PuppetMetadata
       # @return [Array] All Operating System versions that aren't EoL today
       def supported_releases(operatingsystem)
         releases = EOL_DATES[operatingsystem]
+
+        # return an empty array if one OS has zero dates
+        # Happens for esoteric distros like windows, where we currently don't have any data in EOL_DATES
+        return [] unless releases
+
         today = Date.today
         releases.select { |_release, eol_date| !eol_date || Date.parse(eol_date) > today }.keys
                 .sort_by { |release| Gem::Version.new(release) }

--- a/spec/operatingsystem_spec.rb
+++ b/spec/operatingsystem_spec.rb
@@ -77,5 +77,17 @@ describe PuppetMetadata::OperatingSystem do
         expect(described_class.supported_releases(os).last).to eq(described_class.latest_release(os))
       end
     end
+
+    context 'with Solaris' do
+      let(:os) { 'Solaris' }
+
+      it 'returns []' do
+        expect(described_class.supported_releases(os)).to be_empty
+      end
+
+      it 'the last entry matches latest_release' do
+        expect(described_class.supported_releases(os).last).to eq(described_class.latest_release(os))
+      end
+    end
   end
 end


### PR DESCRIPTION
The code assumes that the method `supported_releases()` always returns an array, with all supported OS versions. Previously it failed when metadata.json contained an OS where we don't have any listed versions for (e.g. Windows, Solaris, NetBSD...):

```
bundler: failed to load command: bin/puppet-metadata (bin/puppet-metadata)
/home/bastelfreak/code/puppet_metadata/lib/puppet_metadata/operatingsystem.rb:270:in 'PuppetMetadata::OperatingSystem.supported_releases': private method 'select' called for nil (NoMethodError)

        releases.select { |_release, eol_date| !eol_date || Date.parse(eol_date) > today }.keys
                 ^^^^^^^
```