### PR TITLE
add subcommand to list missing OS versions

### DIFF
--- a/lib/puppet_metadata/command/list_missing_os.rb
+++ b/lib/puppet_metadata/command/list_missing_os.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# check for all operating systems, then add all supported versions
+class ListMissingOSCommand < PuppetMetadata::BaseCommand
+  def self.parser(options)
+    OptionParser.new do |opts|
+      opts.set_program_name 'For each OS, list releases that are not EoL and missing'
+      opts.on('--at DATE', Date, 'The date to use') do |value|
+        options[:at] = value
+      end
+      opts.on('--os operatingsystem', nil, 'Only honour the specific operating system') do |value|
+        options[:os] = value
+      end
+    end
+  end
+
+  def run
+    added = metadata.add_supported_operatingsystems(@options[:at], @options[:os])
+
+    if added.any?
+
+      puts 'missing in metadata.json'
+      added.each do |os, releases|
+        puts "#{os} => #{releases.join(', ')}"
+      end
+    else
+      puts 'no OS releases missing'
+    end
+  end
+end


### PR DESCRIPTION
This adds a new subcommand. It checks for all operating systems in metadata.json. It will output all major OS releases that are not yet EoL & missing in metadata.json

```
 $ bundle exec puppet-metadata
Usage: puppet-metadata [options] <action> [options]
        --filename METADATA          Metadata filename

ACTIONS
  list_missing_os     For each OS, list releases that are not EoL and missing
  eol                 Show which operating systems are end of life
  add_supported_os    Add supported operating systems to metadata.json

See 'puppet-metadata ACTION --help' for more information on a specific action.
 $ bundle exec puppet-metadata list_missing_os
missing in metadata.json
AlmaLinux => 10
CentOS => 10
Debian => 13
Fedora => 41, 42
RedHat => 10
Rocky => 10
 $
```