### PR TITLE
Fix `add_supported_os` with os filter

### DIFF
--- a/lib/puppet_metadata/command/add_supported_os.rb
+++ b/lib/puppet_metadata/command/add_supported_os.rb
@@ -8,7 +8,7 @@ class AddSupportedOSCommand < PuppetMetadata::BaseCommand
       opts.on('--at DATE', Date, 'The date to use') do |value|
         options[:at] = value
       end
-      opts.on('--os operatingsystem', nil, 'Only honour the specific operating system') do |value|
+      opts.on('--os OPERATINGSYSTEM', 'Only honour the specific operating system') do |value|
         options[:os] = value
       end
     end

--- a/lib/puppet_metadata/metadata.rb
+++ b/lib/puppet_metadata/metadata.rb
@@ -123,7 +123,11 @@ module PuppetMetadata
 
         # desired_os is a filter
         # if set, we only care about this OS, otherwise we want all OSes from metadata.json
-        next if desired_os && desired_os != os
+        if desired_os && desired_os != os
+          # Preserve the original entry unchanged
+          result['operatingsystemrelease'] = releases unless releases.nil?
+          next result
+        end
 
         unless releases.nil?
           supported = OperatingSystem.supported_releases(os, at)
@@ -133,6 +137,9 @@ module PuppetMetadata
         end
         result
       end
+
+      # Clear the memoized operatingsystems so it gets recalculated
+      @operatingsystems = nil
 
       added
     end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -229,11 +229,19 @@ describe PuppetMetadata::Metadata do
         end
 
         it 'with OS' do
+          # Only Debian should be in the added hash
           expect(subject.add_supported_operatingsystems(nil, desired_os)).to eq({ 'Debian' => ['11', '12', '13'] })
+          # Other OSes should remain unchanged
+          expect(subject.operatingsystems['CentOS']).to eq(['7', '8', '9'])
+          expect(subject.operatingsystems['RedHat']).to eq(['7', '8', '9'])
         end
 
         it 'with date & OS' do
+          # Only Debian should be in the added hash
           expect(subject.add_supported_operatingsystems(date, desired_os)).to eq({ 'Debian' => ['12', '13'] })
+          # Other OSes should remain unchanged
+          expect(subject.operatingsystems['CentOS']).to eq(['7', '8', '9'])
+          expect(subject.operatingsystems['RedHat']).to eq(['7', '8', '9'])
         end
       end
     end


### PR DESCRIPTION
Fix the behavior of `add_supported_os` with the `--os` filter

Fixes https://github.com/voxpupuli/puppet_metadata/issues/201
